### PR TITLE
Improve advisor dashboard

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/advisor/AdvisorDashboardController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/advisor/AdvisorDashboardController.java
@@ -32,8 +32,7 @@ public class AdvisorDashboardController {
 
     @GetMapping("/advisor-dashboard")
     public String advisorDashboard(@AuthenticationPrincipal OidcUser oidcUser, Model model) {
-        //User advisor = userRepository.findByEmail(oidcUser.getEmail()).orElseThrow();
-    	User advisor = userRepository.findByEmail("advisor.john.doe@uanl.edu.mx").orElseThrow();
+        User advisor = userRepository.findByEmail(oidcUser.getEmail()).orElseThrow();
         List<Match> acceptedMatches = matchRepository.findByAdvisorAndStatus(advisor, MatchStatus.ACCEPTED);
 
         List<Project> availableProjects = new ArrayList<>();
@@ -46,7 +45,14 @@ public class AdvisorDashboardController {
             }
         }
 
+        int matchCount = matchRepository.findByAdvisor(advisor).size();
+        int projectCount = projectRepository.findByAdvisor(advisor).size();
+        int availableProjectCount = availableProjects.size();
+
         model.addAttribute("availableProjects", availableProjects);
+        model.addAttribute("matchCount", matchCount);
+        model.addAttribute("projectCount", projectCount);
+        model.addAttribute("availableProjectCount", availableProjectCount);
         model.addAttribute("advisor", advisor);
         model.addAttribute("matches", matchRepository.findByAdvisor(advisor));
         model.addAttribute("projects", projectRepository.findByAdvisor(advisor));

--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -1,14 +1,50 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-<title>Advisor Dashboard</title>
-<link
-	href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
-	rel="stylesheet">
+    <title>Advisor Dashboard</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </head>
 <body>
-	<div class="container mt-4">
-		<h2 th:text="'Welcome, ' + ${advisor.fullName}">Advisor Name</h2>
+    <nav class="navbar navbar-dark bg-dark navbar-expand-lg">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="#">AsesorMatch</a>
+            <div class="d-flex">
+                <a class="nav-link text-white" href="/logout">Logout</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container mt-4">
+        <h2 th:text="'Welcome, ' + ${advisor.fullName}">Advisor Name</h2>
+
+        <div class="row text-center my-4">
+            <div class="col-md-4 mb-3">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">Matches</h5>
+                        <p class="display-6" th:text="${matchCount}">0</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4 mb-3">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">Projects</h5>
+                        <p class="display-6" th:text="${projectCount}">0</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4 mb-3">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">Unassigned</h5>
+                        <p class="display-6" th:text="${availableProjectCount}">0</p>
+                    </div>
+                </div>
+            </div>
+        </div>
 
 		<h4 class="mt-4">Matches Assigned to You</h4>
 		<table class="table table-striped">


### PR DESCRIPTION
## Summary
- enhance `AdvisorDashboardController` to use the logged in user and expose counts for matches and projects
- restyle `advisor-dashboard.html` with Bootstrap navbar and summary cards

## Testing
- `./mvnw -q test` *(fails: Failed to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6875b5490c348320af0b04271d6a9283