### PR TITLE
Fix recommendations fragment name

### DIFF
--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -111,7 +111,7 @@
 			<th:block th:if="${!#lists.isEmpty(recommendations)}">
 				<hr>
 				<h4>Recommendations</h4>
-				<th:block th:replace="~{fragments/advisorFragments :: recomendationsTable(${recommendations})}"></th:block>
+                                <th:block th:replace="~{fragments/advisorFragments :: recommendationsTable(${recommendations})}"></th:block>
 			</th:block>
 
 			<div th:replace="~{fragments/advisorFragments :: profileModal}"></div>

--- a/src/main/resources/templates/fragments/advisorFragments.html
+++ b/src/main/resources/templates/fragments/advisorFragments.html
@@ -4,7 +4,7 @@
 <title>Fragments</title>
 </head>
 <body>
-	<table class="table table-striped align-middle" th:fragment="recomendationsTable (recommendations)">
+        <table class="table table-striped align-middle" th:fragment="recommendationsTable (recommendations)">
 		<thead class="table-light">
 			<tr>
 				<th>Advisor</th>


### PR DESCRIPTION
## Summary
- rename fragment `recomendationsTable` to `recommendationsTable`
- update dashboard to reference the new fragment

## Testing
- `mvnw -q test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6875b5907444832083b334c32135c51b