### PR TITLE
Add MatchingService persistence test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,16 +62,21 @@
 			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-client</artifactId>

--- a/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
@@ -1,0 +1,60 @@
+package com.uanl.asesormatch.service;
+
+import com.uanl.asesormatch.entity.Match;
+import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.enums.MatchStatus;
+import com.uanl.asesormatch.enums.Role;
+import com.uanl.asesormatch.repository.MatchRepository;
+import com.uanl.asesormatch.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+class MatchingServiceTests {
+
+    @Autowired
+    private MatchRepository matchRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private MatchingService matchingService;
+
+    @BeforeEach
+    void setUp() {
+        matchingService = new MatchingService(matchRepository, userRepository);
+    }
+
+    @Test
+    void requestMatchPersistsPendingMatch() {
+        User student = new User();
+        student.setFullName("Student Test");
+        student.setEmail("student@test.com");
+        student.setRole(Role.STUDENT);
+        userRepository.save(student);
+
+        User advisor = new User();
+        advisor.setFullName("Advisor Test");
+        advisor.setEmail("advisor@test.com");
+        advisor.setRole(Role.ADVISOR);
+        userRepository.save(advisor);
+
+        double score = 0.85;
+        matchingService.requestMatch(student.getId(), advisor.getId(), score);
+
+        List<Match> persisted = matchRepository.findAll();
+        assertEquals(1, persisted.size());
+        Match match = persisted.get(0);
+
+        assertEquals(student.getId(), match.getStudent().getId());
+        assertEquals(advisor.getId(), match.getAdvisor().getId());
+        assertEquals(score, match.getCompatibilityScore());
+        assertEquals(MatchStatus.PENDING, match.getStatus());
+    }
+}


### PR DESCRIPTION
## Summary
- add `MatchingServiceTests` to verify `requestMatch` saves a pending match in an H2 in-memory DB
- include H2 test dependency

## Testing
- `./mvnw test -q` *(fails: unable to download Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_6875b5a6d9c083208c8f88c1b66cafb4