### PR TITLE
Show full advisor profile in dashboard modal

### DIFF
--- a/src/main/java/com/uanl/asesormatch/client/MatchingEngineClient.java
+++ b/src/main/java/com/uanl/asesormatch/client/MatchingEngineClient.java
@@ -37,8 +37,8 @@ public class MatchingEngineClient {
         payload.put("modality", studentVector.getModality());
         payload.put("language", studentVector.getLanguage());
 
-        if (studentVector.getUser() != null) {
-            payload.put("userId", studentVector.getUser().getId());
+        if (studentVector.getUserId() != null) {
+            payload.put("userId", studentVector.getUserId());
         }
 
         if (studentVector.getBooks() != null) {

--- a/src/main/java/com/uanl/asesormatch/dto/AdvisorProfileDTO.java
+++ b/src/main/java/com/uanl/asesormatch/dto/AdvisorProfileDTO.java
@@ -1,13 +1,9 @@
 package com.uanl.asesormatch.dto;
 
-import java.util.List;
-
 public record AdvisorProfileDTO(
-        Long   id,
-        String fullName,
-        String email,
-        String faculty,
-        List<String> areas,
-        List<String> interests,
-        String language
+        Long       id,
+        String     fullName,
+        String     email,
+        String     faculty,
+        ProfileDTO profile
 ) {}

--- a/src/main/java/com/uanl/asesormatch/dto/ProfileDTO.java
+++ b/src/main/java/com/uanl/asesormatch/dto/ProfileDTO.java
@@ -3,7 +3,6 @@ package com.uanl.asesormatch.dto;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.uanl.asesormatch.entity.User;
 
 import jakarta.validation.constraints.NotEmpty;
 
@@ -21,7 +20,7 @@ public class ProfileDTO {
 	private List<BookDTO> books = new ArrayList<>();
 	private String level = null;
 	private String modality = null;
-	private User user = null;
+       private Long userId = null;
 	private String language = null;
 
 	public Long getId() {
@@ -80,13 +79,13 @@ public class ProfileDTO {
 		this.modality = modality;
 	}
 
-	public User getUser() {
-		return user;
-	}
+       public Long getUserId() {
+               return userId;
+       }
 
-	public void setUser(User user) {
-		this.user = user;
-	}
+       public void setUserId(Long userId) {
+               this.userId = userId;
+       }
 
 	public String getLanguage() {
 		return language;
@@ -98,8 +97,8 @@ public class ProfileDTO {
 
 	@Override
 	public String toString() {
-		return "ProfileDTO [id=" + id + ", interests=" + interests + ", areas=" + areas + ", availability="
-				+ availability + ", books=" + books + ", level=" + level + ", modality=" + modality + ", user=" + user
-				+ ", language=" + language + "]";
-	}
+               return "ProfileDTO [id=" + id + ", interests=" + interests + ", areas=" + areas + ", availability="
+                               + availability + ", books=" + books + ", level=" + level + ", modality=" + modality + ", userId=" + userId
+                               + ", language=" + language + "]";
+       }
 }

--- a/src/main/java/com/uanl/asesormatch/entity/Profile.java
+++ b/src/main/java/com/uanl/asesormatch/entity/Profile.java
@@ -124,7 +124,9 @@ public class Profile {
 		dto.setLanguage(language);
 		dto.setLevel(level);
 		dto.setModality(modality);
-		dto.setUser(user);
+               if (user != null) {
+                       dto.setUserId(user.getId());
+               }
 		
 		for (Book book : this.getBooks()) {
 			BookDTO dtoBook = new BookDTO();

--- a/src/main/java/com/uanl/asesormatch/service/AdvisorService.java
+++ b/src/main/java/com/uanl/asesormatch/service/AdvisorService.java
@@ -17,11 +17,14 @@ public class AdvisorService {
 		this.userRepo = userRepo;
 	}
 
-	public Optional<AdvisorProfileDTO> getProfile(Long id) {
-		return userRepo.findById(id).filter(u -> u.getRole() == Role.ADVISOR)
-				.map(u -> new AdvisorProfileDTO(u.getId(), u.getFullName(), u.getEmail(), u.getFaculty(),
-						u.getProfile() != null ? u.getProfile().getAreas() : List.of(),
-						u.getProfile() != null ? u.getProfile().getInterests() : List.of(),
-						u.getProfile() != null ? u.getProfile().getLanguage() : null));
-	}
+        public Optional<AdvisorProfileDTO> getProfile(Long id) {
+                return userRepo.findById(id)
+                                .filter(u -> u.getRole() == Role.ADVISOR)
+                                .map(u -> new AdvisorProfileDTO(
+                                                u.getId(),
+                                                u.getFullName(),
+                                                u.getEmail(),
+                                                u.getFaculty(),
+                                                u.getProfile() != null ? u.getProfile().getDTO() : null));
+        }
 }

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -132,18 +132,26 @@
         </div>
 	<script>
 	/* ------------- utils ---------------- */
-	function buildProfileHTML(user) {
-	    const p = user.profile ?? {};
-	    return `
-	        <p><strong>Name:</strong> ${user.fullName}</p>
-	        <p><strong>Email:</strong> <a href="mailto:${user.email}">${user.email}</a></p>
-	        <p><strong>Faculty:</strong> ${user.faculty ?? '—'}</p>
-	        <hr>
-	        <p><strong>Areas:</strong> ${(p.areas ?? []).join(', ') || '—'}</p>
-	        <p><strong>Interests:</strong> ${(p.interests ?? []).join(', ') || '—'}</p>
-	        <p><strong>Language:</strong> ${p.language ?? '—'}</p>
-	    `;
-	}
+        function buildProfileHTML(user) {
+            const p = user.profile ?? {};
+            const books = (p.books ?? []).map(b =>
+                `<li><strong>${b.title}</strong><br>${b.description ?? ''}</li>`
+            ).join('');
+            return `
+                <p><strong>Name:</strong> ${user.fullName}</p>
+                <p><strong>Email:</strong> <a href="mailto:${user.email}">${user.email}</a></p>
+                <p><strong>Faculty:</strong> ${user.faculty ?? '—'}</p>
+                <hr>
+                <p><strong>Areas:</strong> ${(p.areas ?? []).join(', ') || '—'}</p>
+                <p><strong>Interests:</strong> ${(p.interests ?? []).join(', ') || '—'}</p>
+                <p><strong>Availability:</strong> ${(p.availability ?? []).join(', ') || '—'}</p>
+                <p><strong>Books:</strong></p>
+                <ul>${books || '<li>—</li>'}</ul>
+                <p><strong>Level:</strong> ${p.level ?? '—'}</p>
+                <p><strong>Modality:</strong> ${p.modality ?? '—'}</p>
+                <p><strong>Language:</strong> ${p.language ?? '—'}</p>
+            `;
+        }
 	
 	/* ------------- view-profile buttons ---------------- */
 	document.querySelectorAll('.view-profile').forEach(btn => {


### PR DESCRIPTION
## Summary
- return ProfileDTO when fetching advisor profile information
- display full advisor profile in dashboard recommendations modal
- avoid recursion by keeping only userId in ProfileDTO

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6875d04a906483208325ee9c7cedded9