### PR TITLE
Add profile suggestions feature

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/student/StudentProfileController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/student/StudentProfileController.java
@@ -33,15 +33,24 @@ public class StudentProfileController {
 		this.profileRepository = profileRepository;
 	}
 
-	@GetMapping("/{id}/edit")
-	public String editProfileForm(@PathVariable Long id, Model model) {
-		User user = userRepository.findById(id).orElseThrow();
-		Profile profile = user.getProfile() == null ? new Profile() : user.getProfile();
-		if (profile.getUser() == null)
-			profile.setUser(user);
-		model.addAttribute("profile", profile);
-		return "edit-profile";
-	}
+        @GetMapping("/{id}/edit")
+        public String editProfileForm(@PathVariable Long id, Model model) {
+                User user = userRepository.findById(id).orElseThrow();
+                Profile profile = user.getProfile() == null ? new Profile() : user.getProfile();
+                if (profile.getUser() == null)
+                        profile.setUser(user);
+
+                model.addAttribute("profile", profile);
+
+                model.addAttribute("interestSuggestions", profileRepository.findDistinctInterests());
+                model.addAttribute("areaSuggestions", profileRepository.findDistinctAreas());
+                model.addAttribute("availabilitySuggestions", profileRepository.findDistinctAvailability());
+                model.addAttribute("levelSuggestions", profileRepository.findDistinctLevels());
+                model.addAttribute("modalitySuggestions", profileRepository.findDistinctModalities());
+                model.addAttribute("languageSuggestions", profileRepository.findDistinctLanguages());
+
+                return "edit-profile";
+        }
 
 	@PostMapping("/edit")
 	public String updateProfile(@AuthenticationPrincipal OidcUser oidcUser,

--- a/src/main/java/com/uanl/asesormatch/repository/ProfileRepository.java
+++ b/src/main/java/com/uanl/asesormatch/repository/ProfileRepository.java
@@ -1,9 +1,29 @@
 package com.uanl.asesormatch.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.uanl.asesormatch.entity.Profile;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
+    @Query("SELECT DISTINCT i FROM Profile p JOIN p.interests i")
+    List<String> findDistinctInterests();
+
+    @Query("SELECT DISTINCT a FROM Profile p JOIN p.areas a")
+    List<String> findDistinctAreas();
+
+    @Query("SELECT DISTINCT av FROM Profile p JOIN p.availability av")
+    List<String> findDistinctAvailability();
+
+    @Query("SELECT DISTINCT p.level FROM Profile p WHERE p.level IS NOT NULL")
+    List<String> findDistinctLevels();
+
+    @Query("SELECT DISTINCT p.modality FROM Profile p WHERE p.modality IS NOT NULL")
+    List<String> findDistinctModalities();
+
+    @Query("SELECT DISTINCT p.language FROM Profile p WHERE p.language IS NOT NULL")
+    List<String> findDistinctLanguages();
 }

--- a/src/main/resources/templates/edit-profile.html
+++ b/src/main/resources/templates/edit-profile.html
@@ -9,33 +9,33 @@
 			method="post" class="mt-3">
 
 			<!-- ─── Interests (List<String>) ────────────────────────────── -->
-			<div class="mb-3">
-				<label class="form-label">Interests</label> <input
-					id="interests-input" class="form-control" type="text"
-					th:value="${#strings.arrayJoin(profile.interests, ',')}" />
-				<div id="interests-hidden"></div>
+                        <div class="mb-3">
+                                <label class="form-label">Interests</label> <input
+                                        id="interests-input" class="form-control" type="text"
+                                        th:value="${#strings.arrayJoin(profile.interests, ',')}" />
+                                <div id="interests-hidden"></div>
 
 				<div class="text-danger" th:if="${#fields.hasErrors('interests')}"
 					th:errors="*{interests}"></div>
 			</div>
 
 			<!-- ─── Areas (List<String>) ────────────────────────────────── -->
-			<div class="mb-3">
-				<label class="form-label">Areas</label> <input id="areas-input"
-					class="form-control" type="text"
-					th:value="${#strings.arrayJoin(profile.areas, ',')}" />
-				<div id="areas-hidden"></div>
+                        <div class="mb-3">
+                                <label class="form-label">Areas</label> <input id="areas-input"
+                                        class="form-control" type="text"
+                                        th:value="${#strings.arrayJoin(profile.areas, ',')}" />
+                                <div id="areas-hidden"></div>
 
 				<div class="text-danger" th:if="${#fields.hasErrors('areas')}"
 					th:errors="*{areas}"></div>
 			</div>
 
 			<!-- ─── Availability (List<String>) ─────────────────────────── -->
-			<div class="mb-3">
-				<label class="form-label">Availability</label> <input
-					id="availability-input" class="form-control" type="text"
-					th:value="${#strings.arrayJoin(profile.availability, ',')}" />
-				<div id="availability-hidden"></div>
+                        <div class="mb-3">
+                                <label class="form-label">Availability</label> <input
+                                        id="availability-input" class="form-control" type="text"
+                                        th:value="${#strings.arrayJoin(profile.availability, ',')}" />
+                                <div id="availability-hidden"></div>
 
 				<div class="text-danger"
 					th:if="${#fields.hasErrors('availability')}"
@@ -82,20 +82,29 @@
 				onclick="addBook()">Add book</button>
 
 			<!-- ─── Campos simples ─────────────────────────────────────── -->
-			<div class="mb-3">
-				<label class="form-label">Level</label> <input class="form-control"
-					th:field="*{level}" />
-			</div>
+                        <div class="mb-3">
+                                <label class="form-label">Level</label>
+                                <input class="form-control" th:field="*{level}" list="level-suggestions" />
+                                <datalist id="level-suggestions">
+                                        <option th:each="item : ${levelSuggestions}" th:value="${item}"></option>
+                                </datalist>
+                        </div>
 
-			<div class="mb-3">
-				<label class="form-label">Modality</label> <input
-					class="form-control" th:field="*{modality}" />
-			</div>
+                        <div class="mb-3">
+                                <label class="form-label">Modality</label>
+                                <input class="form-control" th:field="*{modality}" list="modality-suggestions" />
+                                <datalist id="modality-suggestions">
+                                        <option th:each="item : ${modalitySuggestions}" th:value="${item}"></option>
+                                </datalist>
+                        </div>
 
-			<div class="mb-3">
-				<label class="form-label">Language</label> <input
-					class="form-control" th:field="*{language}" />
-			</div>
+                        <div class="mb-3">
+                                <label class="form-label">Language</label>
+                                <input class="form-control" th:field="*{language}" list="language-suggestions" />
+                                <datalist id="language-suggestions">
+                                        <option th:each="item : ${languageSuggestions}" th:value="${item}"></option>
+                                </datalist>
+                        </div>
 
 			<button type="submit" class="btn btn-success">Save</button>
 			<a href="/dashboard" class="btn btn-secondary">Cancel</a>
@@ -105,9 +114,9 @@
 	<!-- ======================  SCRIPTS  ====================== -->
 	<script>
     /* ——— Tagify -> genera inputs ocultos tipo interests[0] ——— */
-    function initTagify(visibleId, hiddenWrapperId, initialList) {
+    function initTagify(visibleId, hiddenWrapperId, initialList, suggestions) {
         const visible = document.getElementById(visibleId);
-        const tagify  = new Tagify(visible);
+        const tagify  = new Tagify(visible, {whitelist: suggestions, dropdown: {maxItems: 20, enabled: 0}});
         if (initialList.length) tagify.addTags(initialList);
 
         const wrapper = document.getElementById(hiddenWrapperId);
@@ -129,10 +138,13 @@
     const initInterests    = /*[[${profile.interests}]]*/ [];
     const initAreas        = /*[[${profile.areas}]]*/ [];
     const initAvailability = /*[[${profile.availability}]]*/ [];
+    const suggestionsInterests    = /*[[${interestSuggestions}]]*/ [];
+    const suggestionsAreas        = /*[[${areaSuggestions}]]*/ [];
+    const suggestionsAvailability = /*[[${availabilitySuggestions}]]*/ [];
 
-    initTagify('interests-input',   'interests-hidden',   initInterests);
-    initTagify('areas-input',       'areas-hidden',       initAreas);
-    initTagify('availability-input','availability-hidden',initAvailability);
+    initTagify('interests-input',   'interests-hidden',   initInterests, suggestionsInterests);
+    initTagify('areas-input',       'areas-hidden',       initAreas, suggestionsAreas);
+    initTagify('availability-input','availability-hidden',initAvailability, suggestionsAvailability);
 
     /* ——— Books dinámicos ——— */
     let bookIndex = document.querySelectorAll('#books-container .book-entry').length;


### PR DESCRIPTION
## Summary
- query unique profile values for suggestions
- supply suggestions in student profile controller
- show suggestions in edit-profile UI via datalists and Tagify

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68785d32ca70832082fceb80f4500dae