### PR TITLE
Add dynamic recommendation messages

### DIFF
--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -153,10 +153,18 @@
             if (!recs.length) {
                 return '<p>No results found.</p>';
             }
-            const rows = recs.map(r => `
-                <tr>
-                    <td>${r.name}</td>
-                    <td>${r.score}</td>
+
+            const hasAboveHalf = recs.some(r => r.score > 0.50);
+
+            const rows = recs.map(r => {
+                const percent  = Math.round(r.score * 100);
+                const badge    = r.score > 0.70 ?
+                    ' <span class="badge bg-success ms-2">Este maestro es perfecto para ti</span>' : '';
+                const rowClass = r.score > 0.70 ? ' class="table-success"' : '';
+                return `
+                <tr${rowClass}>
+                    <td>${r.name}${badge}</td>
+                    <td>${percent}%</td>
                     <td class="text-center">
                         <button type="button" class="btn btn-outline-secondary btn-sm me-1 view-profile" data-advisor-id="${r.advisorId}" title="View profile">
                             <i class="bi bi-eye"></i>
@@ -165,9 +173,10 @@
                             <i class="bi bi-hand-thumbs-up"></i>
                         </button>
                     </td>
-                </tr>
-            `).join('');
-            return `
+                </tr>`;
+            }).join('');
+
+            const table = `
                 <table class="table table-striped align-middle">
                     <thead class="table-light">
                         <tr>
@@ -178,11 +187,16 @@
                     </thead>
                     <tbody>${rows}</tbody>
                 </table>`;
+
+            if (!hasAboveHalf) {
+                return `<div class="alert alert-warning">Por ahora no pudimos encontrar un maestro en base a tu perfil</div>` + table;
+            }
+            return table;
         }
 
         function buildNewRecommendationsList(recs) {
             if (!recs.length) return '';
-            const items = recs.map(r => `<li><span>${r.name}</span> — score: <span>${r.score}</span></li>`).join('');
+            const items = recs.map(r => `<li><span>${r.name}</span> — score: <span>${Math.round(r.score * 100)}%</span></li>`).join('');
             return `<h5 class="mt-4">Other Recommended Advisors:</h5><ul>${items}</ul>`;
         }
 


### PR DESCRIPTION
## Summary
- give feedback in recommendations tab when no advisor is above 50%
- highlight advisors above 70% as perfect match
- display scores as percentages

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68785feb049c8320b1a6a0b1f947717b