### PR TITLE
Adjust recommendation message threshold

### DIFF
--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -154,7 +154,7 @@
                 return '<p>No results found.</p>';
             }
 
-            const hasAboveHalf = recs.some(r => r.score > 0.50);
+            const hasAboveTen = recs.some(r => r.score > 0.10);
 
             const rows = recs.map(r => {
                 const percent  = Math.round(r.score * 100);
@@ -188,7 +188,7 @@
                     <tbody>${rows}</tbody>
                 </table>`;
 
-            if (!hasAboveHalf) {
+            if (!hasAboveTen) {
                 return `<div class="alert alert-warning">Por ahora no pudimos encontrar un maestro en base a tu perfil</div>` + table;
             }
             return table;


### PR DESCRIPTION
## Summary
- update the dashboard recommendations logic so the warning message only
  shows if all scores are 10% or lower

## Testing
- `./mvnw test -q` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687862d0b2b88320a90bb388a69f2f8a