### PR TITLE
Enable advisor view of student profiles

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/advisor/StudentController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/advisor/StudentController.java
@@ -1,0 +1,29 @@
+package com.uanl.asesormatch.controller.advisor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.uanl.asesormatch.dto.StudentProfileDTO;
+import com.uanl.asesormatch.service.StudentService;
+
+@RestController
+@RequestMapping("/api/students")
+@CrossOrigin(origins = "*")
+public class StudentController {
+    private final StudentService studentService;
+
+    public StudentController(StudentService studentService) {
+        this.studentService = studentService;
+    }
+
+    @GetMapping("/profile/{id}")
+    public ResponseEntity<StudentProfileDTO> profile(@PathVariable Long id) {
+        return studentService.getProfile(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/uanl/asesormatch/dto/ProjectDTO.java
+++ b/src/main/java/com/uanl/asesormatch/dto/ProjectDTO.java
@@ -1,22 +1,40 @@
 package com.uanl.asesormatch.dto;
 
 public class ProjectDTO {
-	private String title;
-	private String description;
+        private Long id;
+        private String title;
+        private String description;
+        private String status;
 
-	public String getTitle() {
-		return title;
-	}
+        public Long getId() {
+                return id;
+        }
 
-	public void setTitle(String title) {
-		this.title = title;
-	}
+        public void setId(Long id) {
+                this.id = id;
+        }
 
-	public String getDescription() {
-		return description;
-	}
+        public String getTitle() {
+                return title;
+        }
 
-	public void setDescription(String description) {
-		this.description = description;
-	}
+        public void setTitle(String title) {
+                this.title = title;
+        }
+
+        public String getDescription() {
+                return description;
+        }
+
+        public void setDescription(String description) {
+                this.description = description;
+        }
+
+        public String getStatus() {
+                return status;
+        }
+
+        public void setStatus(String status) {
+                this.status = status;
+        }
 }

--- a/src/main/java/com/uanl/asesormatch/dto/StudentProfileDTO.java
+++ b/src/main/java/com/uanl/asesormatch/dto/StudentProfileDTO.java
@@ -1,0 +1,12 @@
+package com.uanl.asesormatch.dto;
+
+import java.util.List;
+
+public record StudentProfileDTO(
+    Long id,
+    String fullName,
+    String email,
+    String faculty,
+    ProfileDTO profile,
+    List<ProjectDTO> projects
+) {}

--- a/src/main/java/com/uanl/asesormatch/service/StudentService.java
+++ b/src/main/java/com/uanl/asesormatch/service/StudentService.java
@@ -1,0 +1,47 @@
+package com.uanl.asesormatch.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.uanl.asesormatch.dto.ProjectDTO;
+import com.uanl.asesormatch.dto.StudentProfileDTO;
+import com.uanl.asesormatch.enums.Role;
+import com.uanl.asesormatch.repository.ProjectRepository;
+import com.uanl.asesormatch.repository.UserRepository;
+
+@Service
+public class StudentService {
+    private final UserRepository userRepo;
+    private final ProjectRepository projectRepo;
+
+    public StudentService(UserRepository userRepo, ProjectRepository projectRepo) {
+        this.userRepo = userRepo;
+        this.projectRepo = projectRepo;
+    }
+
+    public Optional<StudentProfileDTO> getProfile(Long id) {
+        return userRepo.findById(id)
+                .filter(u -> u.getRole() == Role.STUDENT)
+                .map(u -> {
+                    List<ProjectDTO> projects = projectRepo.findByStudent(u).stream().map(p -> {
+                        ProjectDTO dto = new ProjectDTO();
+                        dto.setId(p.getId());
+                        dto.setTitle(p.getTitle());
+                        dto.setDescription(p.getDescription());
+                        dto.setStatus(p.getStatus().name());
+                        return dto;
+                    }).collect(Collectors.toList());
+                    return new StudentProfileDTO(
+                        u.getId(),
+                        u.getFullName(),
+                        u.getEmail(),
+                        u.getFaculty(),
+                        u.getProfile() != null ? u.getProfile().getDTO() : null,
+                        projects
+                    );
+                });
+    }
+}

--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -50,22 +50,27 @@
 					<td th:text="${match.compatibilityScore}">0.00</td>
 					<td th:text="${match.status}">PENDING</td>
                                         <td th:text="${#temporals.format(match.createdAt, 'dd/MM/yyyy')}">date</td>
-					<td>
-						<form th:action="@{/match/decision}" method="post"
-							style="display: inline;">
-							<input type="hidden" name="matchId" th:value="${match.id}" /> <input
-								type="hidden" name="action" value="ACCEPTED" />
-							<button type="submit" class="btn btn-success btn-sm"
-								th:disabled="${match.status != 'PENDING'}">Accept</button>
-						</form>
-						<form th:action="@{/match/decision}" method="post"
-							style="display: inline;">
-							<input type="hidden" name="matchId" th:value="${match.id}" /> <input
-								type="hidden" name="action" value="REJECTED" />
-							<button type="submit" class="btn btn-danger btn-sm"
-								th:disabled="${match.status != 'PENDING'}">Reject</button>
-						</form>
-					</td>
+                                        <td>
+                                                <button type="button"
+                                                        class="btn btn-outline-secondary btn-sm me-1 view-student-profile"
+                                                        th:data-student-id="${match.student.id}" title="View profile">
+                                                        <i class="bi bi-eye"></i>
+                                                </button>
+                                                <form th:action="@{/match/decision}" method="post"
+                                                        style="display: inline;">
+                                                        <input type="hidden" name="matchId" th:value="${match.id}" /> <input
+                                                                type="hidden" name="action" value="ACCEPTED" />
+                                                        <button type="submit" class="btn btn-success btn-sm"
+                                                                th:disabled="${match.status != 'PENDING'}">Accept</button>
+                                                </form>
+                                                <form th:action="@{/match/decision}" method="post"
+                                                        style="display: inline;">
+                                                        <input type="hidden" name="matchId" th:value="${match.id}" /> <input
+                                                                type="hidden" name="action" value="REJECTED" />
+                                                        <button type="submit" class="btn btn-danger btn-sm"
+                                                                th:disabled="${match.status != 'PENDING'}">Reject</button>
+                                                </form>
+                                        </td>
 
 				</tr>
 			</tbody>
@@ -90,35 +95,95 @@
 			</tbody>
 		</table>
 		<h4 class="mt-5">Unassigned Projects from Matched Students</h4>
-		<table class="table">
-			<thead>
-				<tr>
-					<th>Student</th>
-					<th>Title</th>
-					<th>Description</th>
-					<th>Action</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr th:each="project : ${availableProjects}">
-					<td th:text="${project.student.fullName}">Student Name</td>
-					<td th:text="${project.title}">Title</td>
-					<td th:text="${project.description}">Description</td>
-					<td>
-						<form th:action="@{/project/assign}" method="post"
-							style="display: inline;">
-							<input type="hidden" name="projectId" th:value="${project.id}" />
-							<button type="submit" class="btn btn-sm btn-success">Accept</button>
-						</form>
-						<form th:action="@{/project/reject}" method="post"
-							style="display: inline;">
-							<input type="hidden" name="projectId" th:value="${project.id}" />
-							<button type="submit" class="btn btn-sm btn-danger">Reject</button>
-						</form>
-					</td>
-				</tr>
-			</tbody>
-		</table>
-	</div>
+                <table class="table">
+                        <thead>
+                                <tr>
+                                        <th>Student</th>
+                                        <th>Title</th>
+                                        <th>Description</th>
+                                        <th>Action</th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                <tr th:each="project : ${availableProjects}">
+                                        <td th:text="${project.student.fullName}">Student Name</td>
+                                        <td th:text="${project.title}">Title</td>
+                                        <td th:text="${project.description}">Description</td>
+                                        <td>
+                                                <form th:action="@{/project/assign}" method="post"
+                                                        style="display: inline;">
+                                                        <input type="hidden" name="projectId" th:value="${project.id}" />
+                                                        <button type="submit" class="btn btn-sm btn-success">Accept</button>
+                                                </form>
+                                                <form th:action="@{/project/reject}" method="post"
+                                                        style="display: inline;">
+                                                        <input type="hidden" name="projectId" th:value="${project.id}" />
+                                                        <button type="submit" class="btn btn-sm btn-danger">Reject</button>
+                                                </form>
+                                        </td>
+                                </tr>
+                        </tbody>
+                </table>
+                <div th:replace="~{fragments/advisorFragments :: profileModal}"></div>
+        </div>
+        <script>
+        function buildStudentProfileHTML(user) {
+            const p = user.profile ?? {};
+            const books = (p.books ?? []).map(b =>
+                `<li><strong>${b.title}</strong><br>${b.description ?? ''}</li>`
+            ).join('');
+            const projects = (user.projects ?? []).map(pr => `
+                <tr>
+                    <td>${pr.title}</td>
+                    <td>${pr.description ?? ''}</td>
+                    <td>${pr.status}</td>
+                </tr>`).join('');
+            const projectTable = projects ? `
+                <h5 class="mt-4">Projects</h5>
+                <table class="table">
+                    <thead>
+                        <tr><th>Title</th><th>Description</th><th>Status</th></tr>
+                    </thead>
+                    <tbody>${projects}</tbody>
+                </table>` : '<p>No projects found.</p>';
+            return `
+                <p><strong>Name:</strong> ${user.fullName}</p>
+                <p><strong>Email:</strong> <a href="mailto:${user.email}">${user.email}</a></p>
+                <p><strong>Faculty:</strong> ${user.faculty ?? '—'}</p>
+                <hr>
+                <p><strong>Areas:</strong> ${(p.areas ?? []).join(', ') || '—'}</p>
+                <p><strong>Interests:</strong> ${(p.interests ?? []).join(', ') || '—'}</p>
+                <p><strong>Availability:</strong> ${(p.availability ?? []).join(', ') || '—'}</p>
+                <p><strong>Books:</strong></p>
+                <ul>${books || '<li>—</li>'}</ul>
+                <p><strong>Level:</strong> ${p.level ?? '—'}</p>
+                <p><strong>Modality:</strong> ${p.modality ?? '—'}</p>
+                <p><strong>Language:</strong> ${p.language ?? '—'}</p>
+                ${projectTable}
+            `;
+        }
+
+        document.querySelectorAll('.view-student-profile').forEach(btn => {
+            btn.addEventListener('click', async () => {
+                const id  = btn.dataset.studentId;
+                const mod = new bootstrap.Modal('#profileModal');
+                const url = `/api/students/profile/${id}`;
+
+                try {
+                    const res  = await fetch(url, {headers:{'X-Requested-With':'XMLHttpRequest'}});
+                    if (!res.ok) throw new Error(res.status);
+                    const user = await res.json();
+
+                    document.getElementById('profileModalTitle').textContent = user.fullName;
+                    document.getElementById('profileModalBody').innerHTML    = buildStudentProfileHTML(user);
+                } catch (e) {
+                    document.getElementById('profileModalTitle').textContent = 'Error';
+                    document.getElementById('profileModalBody').innerHTML =
+                        `<p class="text-danger">Unable to load profile (status ${e}).</p>`;
+                }
+                mod.show();
+            });
+        });
+        </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add StudentService and StudentController endpoint `/api/students/profile/{id}`
- extend `ProjectDTO` for id and status
- show student profiles in advisor dashboard using a modal
- remove unused `StudentDetailController` and page

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6878773098348320acd9f1c4009c5695