### PR TITLE
Fix match action buttons

### DIFF
--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -61,14 +61,14 @@
                                                         <input type="hidden" name="matchId" th:value="${match.id}" /> <input
                                                                 type="hidden" name="action" value="ACCEPTED" />
                                                         <button type="submit" class="btn btn-success btn-sm"
-                                                                th:disabled="${match.status != 'PENDING'}">Accept</button>
+                                                                th:disabled="${match.status != T(com.uanl.asesormatch.enums.MatchStatus).PENDING}">Accept</button>
                                                 </form>
                                                 <form th:action="@{/match/decision}" method="post"
                                                         style="display: inline;">
                                                         <input type="hidden" name="matchId" th:value="${match.id}" /> <input
                                                                 type="hidden" name="action" value="REJECTED" />
                                                         <button type="submit" class="btn btn-danger btn-sm"
-                                                                th:disabled="${match.status != 'PENDING'}">Reject</button>
+                                                                th:disabled="${match.status != T(com.uanl.asesormatch.enums.MatchStatus).PENDING}">Reject</button>
                                                 </form>
                                         </td>
 


### PR DESCRIPTION
## Summary
- enable accept/reject buttons by comparing match status enum values correctly

## Testing
- `./mvnw -q test` *(fails: could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68787d5c037883208b33fbc81c35f09d