### PR TITLE
Fix advisor dashboard score format

### DIFF
--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -47,7 +47,7 @@
 			<tbody>
 				<tr th:each="match : ${matches}">
 					<td th:text="${match.student.fullName}">Student Name</td>
-					<td th:text="${match.compatibilityScore}">0.00</td>
+                                        <td th:text="${T(java.lang.Math).round(match.compatibilityScore * 100)} + '%'">0%</td>
 					<td th:text="${match.status}">PENDING</td>
                                         <td th:text="${#temporals.format(match.createdAt, 'dd/MM/yyyy')}">date</td>
                                         <td>


### PR DESCRIPTION
## Summary
- show compatibility score as whole-number percentage on advisor dashboard

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68787ec1e51c8320893ece4d0e3cef96