### PR TITLE
Handle project assignment after advisor acceptance

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/student/DashboardController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/student/DashboardController.java
@@ -11,6 +11,7 @@ import com.uanl.asesormatch.enums.Role;
 import com.uanl.asesormatch.repository.ProjectRepository;
 import com.uanl.asesormatch.repository.UserRepository;
 import com.uanl.asesormatch.service.MatchingService;
+import com.uanl.asesormatch.service.NotificationService;
 
 import java.util.List;
 
@@ -27,14 +28,17 @@ public class DashboardController {
 	private final UserRepository userRepository;
 	private final MatchingEngineClient matchingEngineClient;
 	private final MatchingService matchingService;
-	private final ProjectRepository projectRepository;
+        private final ProjectRepository projectRepository;
+        private final NotificationService notificationService;
 
         public DashboardController(UserRepository userRepository, MatchingEngineClient matchingEngineClient,
-                        MatchingService matchingService, ProjectRepository projectRepository) {
+                        MatchingService matchingService, ProjectRepository projectRepository,
+                        NotificationService notificationService) {
                 this.userRepository = userRepository;
                 this.matchingEngineClient = matchingEngineClient;
                 this.matchingService = matchingService;
                 this.projectRepository = projectRepository;
+                this.notificationService = notificationService;
         }
 
         @GetMapping("/api/recommendations")
@@ -66,8 +70,8 @@ public class DashboardController {
         }
 
 	@GetMapping("/dashboard")
-	public String dashboard(@AuthenticationPrincipal OidcUser oidcUser, Model model) {
-		User user = userRepository.findByEmail(oidcUser.getEmail()).orElseThrow();
+        public String dashboard(@AuthenticationPrincipal OidcUser oidcUser, Model model) {
+                User user = userRepository.findByEmail(oidcUser.getEmail()).orElseThrow();
 
 		if (user.getRole() == Role.ADVISOR) {
 			return "redirect:/advisor-dashboard";
@@ -76,11 +80,13 @@ public class DashboardController {
                 Profile profile = user.getProfile();
                 List<Match> matchHistory = matchingService.getMatchesForStudent(user);
                 List<Project> studentProjects = projectRepository.findByStudent(user);
+                var notifications = notificationService.getNotificationsFor(user);
 
-		model.addAttribute("user", user);
-		model.addAttribute("profile", profile);
-		model.addAttribute("matches", matchHistory);
-		model.addAttribute("studentProjects", studentProjects);
+                model.addAttribute("user", user);
+                model.addAttribute("profile", profile);
+                model.addAttribute("matches", matchHistory);
+                model.addAttribute("studentProjects", studentProjects);
+                model.addAttribute("notifications", notifications);
 
 		return "dashboard";
 	}

--- a/src/main/java/com/uanl/asesormatch/entity/Notification.java
+++ b/src/main/java/com/uanl/asesormatch/entity/Notification.java
@@ -1,0 +1,61 @@
+package com.uanl.asesormatch.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private User user;
+
+    private String message;
+
+    private LocalDateTime createdAt;
+
+    private boolean read;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public boolean isRead() {
+        return read;
+    }
+
+    public void setRead(boolean read) {
+        this.read = read;
+    }
+}

--- a/src/main/java/com/uanl/asesormatch/repository/NotificationRepository.java
+++ b/src/main/java/com/uanl/asesormatch/repository/NotificationRepository.java
@@ -1,0 +1,11 @@
+package com.uanl.asesormatch.repository;
+
+import com.uanl.asesormatch.entity.Notification;
+import com.uanl.asesormatch.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByUserOrderByCreatedAtDesc(User user);
+}

--- a/src/main/java/com/uanl/asesormatch/service/MatchingService.java
+++ b/src/main/java/com/uanl/asesormatch/service/MatchingService.java
@@ -3,8 +3,11 @@ package com.uanl.asesormatch.service;
 import com.uanl.asesormatch.entity.Match;
 import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.enums.MatchStatus;
+import com.uanl.asesormatch.enums.ProjectStatus;
 import com.uanl.asesormatch.repository.MatchRepository;
+import com.uanl.asesormatch.repository.ProjectRepository;
 import com.uanl.asesormatch.repository.UserRepository;
+import com.uanl.asesormatch.service.NotificationService;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -15,13 +18,18 @@ import java.util.Map;
 @Service
 public class MatchingService {
 
-	private final MatchRepository matchRepository;
-	private final UserRepository userRepository;
+    private final MatchRepository matchRepository;
+    private final UserRepository userRepository;
+    private final ProjectRepository projectRepository;
+    private final NotificationService notificationService;
 
-	public MatchingService(MatchRepository matchRepository, UserRepository userRepository) {
-		this.matchRepository = matchRepository;
-		this.userRepository = userRepository;
-	}
+    public MatchingService(MatchRepository matchRepository, UserRepository userRepository,
+                          ProjectRepository projectRepository, NotificationService notificationService) {
+        this.matchRepository = matchRepository;
+        this.userRepository = userRepository;
+        this.projectRepository = projectRepository;
+        this.notificationService = notificationService;
+    }
 
 	public List<Match> createMatches(User student, List<Map<String, Object>> recommendations) {
 		List<Match> matches = new ArrayList<>();
@@ -55,13 +63,30 @@ public class MatchingService {
 		return matchRepository.findByStudent(student);
 	}
 
-	public void updateMatchStatus(Long matchId, MatchStatus status) {
-		var match = matchRepository.findById(matchId);
-		match.ifPresent(m -> {
-			m.setStatus(status);
-			matchRepository.save(m);
-		});
-	}
+        public void updateMatchStatus(Long matchId, MatchStatus status) {
+                var matchOpt = matchRepository.findById(matchId);
+                matchOpt.ifPresent(m -> {
+                        m.setStatus(status);
+                        matchRepository.save(m);
+
+                        if (status == MatchStatus.ACCEPTED) {
+                                // Assign first unassigned project from student to advisor
+                                var projects = projectRepository.findByStudent(m.getStudent());
+                                for (var p : projects) {
+                                        if (p.getAdvisor() == null) {
+                                                p.setAdvisor(m.getAdvisor());
+                                                p.setStatus(ProjectStatus.IN_PROGRESS);
+                                                projectRepository.save(p);
+                                                break;
+                                        }
+                                }
+
+                                String msg = "El maestro " + m.getAdvisor().getFullName()
+                                                + " aprob\u00F3 ser tu tutor.";
+                                notificationService.notify(m.getStudent(), msg);
+                        }
+                });
+        }
 
 	public void requestMatch(Long studentId, Long advisorId, Double score) {
 		User student = userRepository.findById(studentId).orElseThrow(() -> new IllegalArgumentException("student"));

--- a/src/main/java/com/uanl/asesormatch/service/NotificationService.java
+++ b/src/main/java/com/uanl/asesormatch/service/NotificationService.java
@@ -1,0 +1,31 @@
+package com.uanl.asesormatch.service;
+
+import com.uanl.asesormatch.entity.Notification;
+import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class NotificationService {
+    private final NotificationRepository repo;
+
+    public NotificationService(NotificationRepository repo) {
+        this.repo = repo;
+    }
+
+    public void notify(User user, String message) {
+        Notification n = new Notification();
+        n.setUser(user);
+        n.setMessage(message);
+        n.setCreatedAt(LocalDateTime.now());
+        n.setRead(false);
+        repo.save(n);
+    }
+
+    public List<Notification> getNotificationsFor(User user) {
+        return repo.findByUserOrderByCreatedAtDesc(user);
+    }
+}

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -12,6 +12,9 @@
                                 <p class="card-text"><strong>Last login:</strong> <span th:text="${#temporals.format(user.lastLogin, 'dd/MM/yyyy')}">date</span></p>
                         </div>
                 </div>
+                <div th:if="${notifications != null and !#lists.isEmpty(notifications)}" class="mb-4">
+                        <div class="alert alert-info" th:each="n : ${notifications}" th:text="${n.message}"></div>
+                </div>
 
                 <ul class="nav nav-tabs" id="dashboardTabs" role="tablist">
                         <li class="nav-item" role="presentation">

--- a/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
@@ -5,7 +5,10 @@ import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.enums.MatchStatus;
 import com.uanl.asesormatch.enums.Role;
 import com.uanl.asesormatch.repository.MatchRepository;
+import com.uanl.asesormatch.repository.ProjectRepository;
 import com.uanl.asesormatch.repository.UserRepository;
+import com.uanl.asesormatch.repository.NotificationRepository;
+import com.uanl.asesormatch.service.NotificationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,11 +27,18 @@ class MatchingServiceTests {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
     private MatchingService matchingService;
 
     @BeforeEach
     void setUp() {
-        matchingService = new MatchingService(matchRepository, userRepository);
+        NotificationService notificationService = new NotificationService(notificationRepository);
+        matchingService = new MatchingService(matchRepository, userRepository, projectRepository, notificationService);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- create Notification entity and service
- assign a student's project when a match is accepted
- notify the student of advisor approval
- show notifications in the student dashboard
- update tests for new MatchingService dependencies

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68787f9551e0832099011cc239bcc3b5