### PR TITLE
Cancel other student matches when advisor accepts

### DIFF
--- a/src/main/java/com/uanl/asesormatch/service/MatchingService.java
+++ b/src/main/java/com/uanl/asesormatch/service/MatchingService.java
@@ -81,6 +81,15 @@ public class MatchingService {
                                         }
                                 }
 
+                                // Cancel other matches for this student
+                                var allMatches = matchRepository.findByStudent(m.getStudent());
+                                for (var other : allMatches) {
+                                        if (!other.getId().equals(m.getId()) && other.getStatus() != MatchStatus.REJECTED) {
+                                                other.setStatus(MatchStatus.REJECTED);
+                                                matchRepository.save(other);
+                                        }
+                                }
+
                                 String msg = "El maestro " + m.getAdvisor().getFullName()
                                                 + " aprob\u00F3 ser tu tutor.";
                                 notificationService.notify(m.getStudent(), msg);


### PR DESCRIPTION
## Summary
- when a match is accepted, reject all other matches for that student
- test match cancellation when a match is accepted

## Testing
- `mvn -q test` *(fails: Could not resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68788295ee988320837c7175fe244b51