### PR TITLE
Display scores as percentages

### DIFF
--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -94,7 +94,7 @@
                                                 <tbody>
                                                         <tr th:each="match : ${matches}">
                                                                 <td><a href="#" class="view-profile" th:data-advisor-id="${match.advisor.id}" th:text="${match.advisor.fullName}">Advisor</a></td>
-                                                                <td th:text="${match.compatibilityScore}">0.00</td>
+                                                                <td th:text="${T(java.lang.Math).round(match.compatibilityScore * 100)} + '%'">0%</td>
                                                                 <td th:text="${match.status}">PENDING</td>
                                                                 <td th:text="${#temporals.format(match.createdAt, 'dd/MM/yyyy')}">2025-06-25</td>
                                                         </tr>

--- a/src/main/resources/templates/fragments/advisorFragments.html
+++ b/src/main/resources/templates/fragments/advisorFragments.html
@@ -16,7 +16,7 @@
 		<tbody>
 			<tr th:each="adv : ${recommendations}">
 				<td th:text="${adv.name}">John Doe</td>
-				<td th:text="${adv.score}">0.90</td>
+                                <td th:text="${T(java.lang.Math).round(adv.score * 100)} + '%'">90%</td>
 				<td class="text-center">
 					<button type="button"
 						class="btn btn-outline-secondary btn-sm me-1 view-profile"


### PR DESCRIPTION
## Summary
- show match scores as percentages in `dashboard.html`
- display advisor recommendation scores as percentages

## Testing
- `./mvnw -q test` *(fails: could not resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878839af0708320a15b9218b4544af2