### PR TITLE
Change unassigned card to completed projects

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/advisor/AdvisorDashboardController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/advisor/AdvisorDashboardController.java
@@ -1,15 +1,11 @@
 package com.uanl.asesormatch.controller.advisor;
 
-import com.uanl.asesormatch.entity.Match;
-import com.uanl.asesormatch.entity.Project;
+import com.uanl.asesormatch.enums.ProjectStatus;
 import com.uanl.asesormatch.entity.User;
-import com.uanl.asesormatch.enums.MatchStatus;
 import com.uanl.asesormatch.repository.MatchRepository;
 import com.uanl.asesormatch.repository.ProjectRepository;
 import com.uanl.asesormatch.repository.UserRepository;
 
-import java.util.ArrayList;
-import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -34,26 +30,15 @@ public class AdvisorDashboardController {
     public String advisorDashboard(@AuthenticationPrincipal OidcUser oidcUser, Model model) {
         //User advisor = userRepository.findByEmail(oidcUser.getEmail()).orElseThrow();
         User advisor = userRepository.findByEmail("advisor.john.doe@uanl.edu.mx").orElseThrow();
-        List<Match> acceptedMatches = matchRepository.findByAdvisorAndStatus(advisor, MatchStatus.ACCEPTED);
-
-        List<Project> availableProjects = new ArrayList<>();
-        for (Match m : acceptedMatches) {
-            List<Project> studentProjects = projectRepository.findByStudent(m.getStudent());
-            for (Project p : studentProjects) {
-                if (p.getAdvisor() == null) {
-                    availableProjects.add(p);
-                }
-            }
-        }
+        long completedProjectCount =
+                projectRepository.countByAdvisorAndStatus(advisor, ProjectStatus.COMPLETED);
 
         int matchCount = matchRepository.findByAdvisor(advisor).size();
         int projectCount = projectRepository.findByAdvisor(advisor).size();
-        int availableProjectCount = availableProjects.size();
 
-        model.addAttribute("availableProjects", availableProjects);
         model.addAttribute("matchCount", matchCount);
         model.addAttribute("projectCount", projectCount);
-        model.addAttribute("availableProjectCount", availableProjectCount);
+        model.addAttribute("completedProjectCount", completedProjectCount);
         model.addAttribute("advisor", advisor);
         model.addAttribute("matches", matchRepository.findByAdvisor(advisor));
         model.addAttribute("projects", projectRepository.findByAdvisor(advisor));

--- a/src/main/java/com/uanl/asesormatch/repository/ProjectRepository.java
+++ b/src/main/java/com/uanl/asesormatch/repository/ProjectRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.uanl.asesormatch.entity.Project;
 import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.enums.ProjectStatus;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     List<Project> findByAdvisor(User advisor);
 
-	List<Project> findByStudent(User user);
+    List<Project> findByStudent(User user);
+
+    long countByAdvisorAndStatus(User advisor, ProjectStatus status);
 }

--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -26,8 +26,8 @@
             <div class="col-md-4 mb-3">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">Unassigned</h5>
-                        <p class="display-6" th:text="${availableProjectCount}">0</p>
+                        <h5 class="card-title">Proyectos completados con los estudiantes</h5>
+                        <p class="display-6" th:text="${completedProjectCount}">0</p>
                     </div>
                 </div>
             </div>
@@ -94,36 +94,6 @@
 				</tr>
 			</tbody>
 		</table>
-		<h4 class="mt-5">Unassigned Projects from Matched Students</h4>
-                <table class="table">
-                        <thead>
-                                <tr>
-                                        <th>Student</th>
-                                        <th>Title</th>
-                                        <th>Description</th>
-                                        <th>Action</th>
-                                </tr>
-                        </thead>
-                        <tbody>
-                                <tr th:each="project : ${availableProjects}">
-                                        <td th:text="${project.student.fullName}">Student Name</td>
-                                        <td th:text="${project.title}">Title</td>
-                                        <td th:text="${project.description}">Description</td>
-                                        <td>
-                                                <form th:action="@{/project/assign}" method="post"
-                                                        style="display: inline;">
-                                                        <input type="hidden" name="projectId" th:value="${project.id}" />
-                                                        <button type="submit" class="btn btn-sm btn-success">Accept</button>
-                                                </form>
-                                                <form th:action="@{/project/reject}" method="post"
-                                                        style="display: inline;">
-                                                        <input type="hidden" name="projectId" th:value="${project.id}" />
-                                                        <button type="submit" class="btn btn-sm btn-danger">Reject</button>
-                                                </form>
-                                        </td>
-                                </tr>
-                        </tbody>
-                </table>
                 <div th:replace="~{fragments/advisorFragments :: profileModal}"></div>
         </div>
         <script>


### PR DESCRIPTION
## Summary
- replace `Unassigned` card with count of completed projects
- remove unassigned projects table from advisor dashboard
- update controller and repository for completed project count

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687884665be48320936924c79d80feca