### PR TITLE
Implement project completion in advisor dashboard

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
@@ -71,9 +71,9 @@ public class ProjectController {
 		return "redirect:/advisor-dashboard";
 	}
 	
-	@PostMapping("/reject")
-	public String rejectProject(@AuthenticationPrincipal OidcUser oidcUser,
-	                            @RequestParam Long projectId) {
+        @PostMapping("/reject")
+        public String rejectProject(@AuthenticationPrincipal OidcUser oidcUser,
+                                    @RequestParam Long projectId) {
 
 	    User advisor = userRepository.findByEmail(oidcUser.getEmail()).orElseThrow();
 	    Project project = projectRepository.findById(projectId).orElseThrow();
@@ -87,6 +87,19 @@ public class ProjectController {
 	        projectRepository.save(project);
 	    }
 
-	    return "redirect:/advisor-dashboard";
-	}
+            return "redirect:/advisor-dashboard";
+        }
+
+        @PostMapping("/complete")
+        public String completeProject(@RequestParam Long matchId) {
+                var match = matchRepository.findById(matchId).orElseThrow();
+                var optProject = projectRepository.findByStudentAndAdvisorAndStatus(
+                                match.getStudent(), match.getAdvisor(), ProjectStatus.IN_PROGRESS);
+                optProject.ifPresent(p -> {
+                        p.setStatus(ProjectStatus.COMPLETED);
+                        projectRepository.save(p);
+                });
+
+                return "redirect:/advisor-dashboard";
+        }
 }

--- a/src/main/java/com/uanl/asesormatch/controller/advisor/AdvisorDashboardController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/advisor/AdvisorDashboardController.java
@@ -1,6 +1,7 @@
 package com.uanl.asesormatch.controller.advisor;
 
 import com.uanl.asesormatch.enums.ProjectStatus;
+import com.uanl.asesormatch.enums.MatchStatus;
 import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.repository.MatchRepository;
 import com.uanl.asesormatch.repository.ProjectRepository;
@@ -36,12 +37,25 @@ public class AdvisorDashboardController {
         int matchCount = matchRepository.findByAdvisor(advisor).size();
         int projectCount = projectRepository.findByAdvisor(advisor).size();
 
+        var matches = matchRepository.findByAdvisor(advisor).stream()
+                .filter(m -> {
+                        if (m.getStatus() == MatchStatus.ACCEPTED) {
+                                return projectRepository.findByStudentAndAdvisorAndStatus(
+                                                m.getStudent(), m.getAdvisor(), ProjectStatus.COMPLETED)
+                                                .isEmpty();
+                        }
+                        return true;
+                }).toList();
+
+        var completedProjects = projectRepository.findByAdvisorAndStatus(advisor, ProjectStatus.COMPLETED);
+
         model.addAttribute("matchCount", matchCount);
         model.addAttribute("projectCount", projectCount);
         model.addAttribute("completedProjectCount", completedProjectCount);
         model.addAttribute("advisor", advisor);
-        model.addAttribute("matches", matchRepository.findByAdvisor(advisor));
+        model.addAttribute("matches", matches);
         model.addAttribute("projects", projectRepository.findByAdvisor(advisor));
+        model.addAttribute("completedProjects", completedProjects);
 
         return "advisor-dashboard";
     }

--- a/src/main/java/com/uanl/asesormatch/repository/ProjectRepository.java
+++ b/src/main/java/com/uanl/asesormatch/repository/ProjectRepository.java
@@ -14,4 +14,8 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     List<Project> findByStudent(User user);
 
     long countByAdvisorAndStatus(User advisor, ProjectStatus status);
+
+    java.util.Optional<Project> findByStudentAndAdvisorAndStatus(User student, User advisor, ProjectStatus status);
+
+    java.util.List<Project> findByAdvisorAndStatus(User advisor, ProjectStatus status);
 }

--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -56,19 +56,21 @@
                                                         th:data-student-id="${match.student.id}" title="View profile">
                                                         <i class="bi bi-eye"></i>
                                                 </button>
-                                                <form th:action="@{/match/decision}" method="post"
-                                                        style="display: inline;">
-                                                        <input type="hidden" name="matchId" th:value="${match.id}" /> <input
-                                                                type="hidden" name="action" value="ACCEPTED" />
+                                                <form th:action="@{/match/decision}" method="post" style="display: inline;">
+                                                        <input type="hidden" name="matchId" th:value="${match.id}" />
+                                                        <input type="hidden" name="action" value="ACCEPTED" />
                                                         <button type="submit" class="btn btn-success btn-sm"
                                                                 th:disabled="${match.status != T(com.uanl.asesormatch.enums.MatchStatus).PENDING}">Accept</button>
                                                 </form>
-                                                <form th:action="@{/match/decision}" method="post"
-                                                        style="display: inline;">
-                                                        <input type="hidden" name="matchId" th:value="${match.id}" /> <input
-                                                                type="hidden" name="action" value="REJECTED" />
+                                                <form th:action="@{/match/decision}" method="post" style="display: inline;">
+                                                        <input type="hidden" name="matchId" th:value="${match.id}" />
+                                                        <input type="hidden" name="action" value="REJECTED" />
                                                         <button type="submit" class="btn btn-danger btn-sm"
                                                                 th:disabled="${match.status != T(com.uanl.asesormatch.enums.MatchStatus).PENDING}">Reject</button>
+                                                </form>
+                                                <form th:if="${match.status == T(com.uanl.asesormatch.enums.MatchStatus).ACCEPTED}" th:action="@{/project/complete}" method="post" style="display: inline;">
+                                                        <input type="hidden" name="matchId" th:value="${match.id}" />
+                                                        <button type="submit" class="btn btn-outline-primary btn-sm">Completado</button>
                                                 </form>
                                         </td>
 
@@ -76,24 +78,42 @@
 			</tbody>
 		</table>
 		<h4 class="mt-5">Projects Assigned</h4>
-		<table class="table table-hover">
-			<thead>
-				<tr>
-					<th>Title</th>
-					<th>Student</th>
-					<th>Status</th>
-					<th>Start Date</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr th:each="project : ${projects}">
-					<td th:text="${project.title}">Project Title</td>
-					<td th:text="${project.student.fullName}">Student</td>
-					<td th:text="${project.status}">IN_PROGRESS</td>
+                <table class="table table-hover">
+                        <thead>
+                                <tr>
+                                        <th>Title</th>
+                                        <th>Student</th>
+                                        <th>Status</th>
+                                        <th>Start Date</th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                <tr th:each="project : ${projects}">
+                                        <td th:text="${project.title}">Project Title</td>
+                                        <td th:text="${project.student.fullName}">Student</td>
+                                        <td th:text="${project.status}">IN_PROGRESS</td>
                                         <td th:text="${#temporals.format(project.startDate, 'dd/MM/yyyy')}">2025-06-28</td>
-				</tr>
-			</tbody>
-		</table>
+                                </tr>
+                        </tbody>
+                </table>
+
+                <h4 class="mt-5">Proyectos completados con los estudiantes</h4>
+                <table class="table table-hover">
+                        <thead>
+                                <tr>
+                                        <th>Title</th>
+                                        <th>Student</th>
+                                        <th>Completed On</th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                <tr th:each="p : ${completedProjects}">
+                                        <td th:text="${p.title}">Project Title</td>
+                                        <td th:text="${p.student.fullName}">Student</td>
+                                        <td th:text="${#temporals.format(p.startDate, 'dd/MM/yyyy')}">2025-06-28</td>
+                                </tr>
+                        </tbody>
+                </table>
                 <div th:replace="~{fragments/advisorFragments :: profileModal}"></div>
         </div>
         <script>


### PR DESCRIPTION
## Summary
- add repository methods to query projects by advisor or student plus status
- support marking projects as completed via `/project/complete`
- filter matches so completed ones do not appear
- list completed projects for advisors
- show `Completado` button in matches table

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687885fdb224832084a0036c80f6edb1