### PR TITLE
Add unit tests for service layer

### DIFF
--- a/src/test/java/com/uanl/asesormatch/service/AdvisorServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/AdvisorServiceTests.java
@@ -1,0 +1,60 @@
+import com.uanl.asesormatch.dto.AdvisorProfileDTO;
+import com.uanl.asesormatch.entity.Profile;
+import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.enums.Role;
+import com.uanl.asesormatch.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class AdvisorServiceTests {
+    @Autowired
+    private UserRepository userRepository;
+
+    private AdvisorService advisorService;
+
+    @BeforeEach
+    void setUp() {
+        advisorService = new AdvisorService(userRepository);
+    }
+
+    @Test
+    void getProfileReturnsAdvisorInfo() {
+        User advisor = new User();
+        advisor.setFullName("Advisor Test");
+        advisor.setEmail("advisor@test.com");
+        advisor.setFaculty("Science");
+        advisor.setRole(Role.ADVISOR);
+
+        Profile profile = new Profile();
+        profile.setLevel("PhD");
+        profile.setUser(advisor);
+        advisor.setProfile(profile);
+
+        userRepository.save(advisor);
+
+        Optional<AdvisorProfileDTO> opt = advisorService.getProfile(advisor.getId());
+        assertTrue(opt.isPresent());
+        AdvisorProfileDTO dto = opt.get();
+        assertEquals("Advisor Test", dto.fullName());
+        assertNotNull(dto.profile());
+        assertEquals("PhD", dto.profile().getLevel());
+    }
+
+    @Test
+    void getProfileReturnsEmptyForNonAdvisor() {
+        User student = new User();
+        student.setFullName("Student");
+        student.setEmail("student@test.com");
+        student.setRole(Role.STUDENT);
+        userRepository.save(student);
+
+        assertTrue(advisorService.getProfile(student.getId()).isEmpty());
+    }
+}

--- a/src/test/java/com/uanl/asesormatch/service/NotificationServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/NotificationServiceTests.java
@@ -1,0 +1,64 @@
+import com.uanl.asesormatch.entity.Notification;
+import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.enums.Role;
+import com.uanl.asesormatch.repository.NotificationRepository;
+import com.uanl.asesormatch.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class NotificationServiceTests {
+    @Autowired
+    private NotificationRepository notificationRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        notificationService = new NotificationService(notificationRepository);
+    }
+
+    @Test
+    void notifyPersistsNotification() {
+        User user = new User();
+        user.setFullName("User Test");
+        user.setEmail("user@test.com");
+        user.setRole(Role.STUDENT);
+        userRepository.save(user);
+
+        notificationService.notify(user, "Hello");
+
+        List<Notification> list = notificationRepository.findByUserOrderByCreatedAtDesc(user);
+        assertEquals(1, list.size());
+        Notification n = list.get(0);
+        assertEquals("Hello", n.getMessage());
+        assertFalse(n.isRead());
+        assertNotNull(n.getCreatedAt());
+        assertEquals(user.getId(), n.getUser().getId());
+    }
+
+    @Test
+    void getNotificationsForReturnsDescending() {
+        User user = new User();
+        user.setFullName("User Test");
+        user.setEmail("user@test.com");
+        user.setRole(Role.STUDENT);
+        userRepository.save(user);
+
+        notificationService.notify(user, "First");
+        notificationService.notify(user, "Second");
+
+        List<Notification> list = notificationService.getNotificationsFor(user);
+        assertEquals(2, list.size());
+        assertEquals("Second", list.get(0).getMessage());
+        assertEquals("First", list.get(1).getMessage());
+    }
+}

--- a/src/test/java/com/uanl/asesormatch/service/StudentServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/StudentServiceTests.java
@@ -1,0 +1,77 @@
+import com.uanl.asesormatch.dto.StudentProfileDTO;
+import com.uanl.asesormatch.dto.ProjectDTO;
+import com.uanl.asesormatch.entity.Project;
+import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.enums.ProjectStatus;
+import com.uanl.asesormatch.enums.Role;
+import com.uanl.asesormatch.repository.ProjectRepository;
+import com.uanl.asesormatch.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class StudentServiceTests {
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    private StudentService studentService;
+
+    @BeforeEach
+    void setUp() {
+        studentService = new StudentService(userRepository, projectRepository);
+    }
+
+    @Test
+    void getProfileReturnsStudentDetailsAndProjects() {
+        User student = new User();
+        student.setFullName("Student Test");
+        student.setEmail("student@test.com");
+        student.setFaculty("Engineering");
+        student.setRole(Role.STUDENT);
+        userRepository.save(student);
+
+        Project p1 = new Project();
+        p1.setTitle("P1");
+        p1.setDescription("D1");
+        p1.setStatus(ProjectStatus.DRAFT);
+        p1.setStudent(student);
+        projectRepository.save(p1);
+
+        Project p2 = new Project();
+        p2.setTitle("P2");
+        p2.setDescription("D2");
+        p2.setStatus(ProjectStatus.IN_PROGRESS);
+        p2.setStudent(student);
+        projectRepository.save(p2);
+
+        Optional<StudentProfileDTO> opt = studentService.getProfile(student.getId());
+        assertTrue(opt.isPresent());
+        StudentProfileDTO dto = opt.get();
+        assertEquals(student.getId(), dto.id());
+        assertEquals("Student Test", dto.fullName());
+        assertEquals(2, dto.projects().size());
+        List<Long> ids = dto.projects().stream().map(ProjectDTO::getId).collect(Collectors.toList());
+        assertTrue(ids.containsAll(List.of(p1.getId(), p2.getId())));
+    }
+
+    @Test
+    void getProfileReturnsEmptyForNonStudent() {
+        User advisor = new User();
+        advisor.setFullName("Advisor");
+        advisor.setEmail("adv@test.com");
+        advisor.setRole(Role.ADVISOR);
+        userRepository.save(advisor);
+
+        assertTrue(studentService.getProfile(advisor.getId()).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add new NotificationService tests
- add StudentService tests
- add AdvisorService tests

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6878875661ac8320846ba355b295be7a