### PR TITLE
Fix order of interests and areas in profile modals

### DIFF
--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -141,8 +141,8 @@
                 <p><strong>Email:</strong> <a href="mailto:${user.email}">${user.email}</a></p>
                 <p><strong>Faculty:</strong> ${user.faculty ?? '—'}</p>
                 <hr>
-                <p><strong>Areas:</strong> ${(p.areas ?? []).join(', ') || '—'}</p>
                 <p><strong>Interests:</strong> ${(p.interests ?? []).join(', ') || '—'}</p>
+                <p><strong>Areas:</strong> ${(p.areas ?? []).join(', ') || '—'}</p>
                 <p><strong>Availability:</strong> ${(p.availability ?? []).join(', ') || '—'}</p>
                 <p><strong>Books:</strong></p>
                 <ul>${books || '<li>—</li>'}</ul>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -141,8 +141,8 @@
                 <p><strong>Email:</strong> <a href="mailto:${user.email}">${user.email}</a></p>
                 <p><strong>Faculty:</strong> ${user.faculty ?? '—'}</p>
                 <hr>
-                <p><strong>Areas:</strong> ${(p.areas ?? []).join(', ') || '—'}</p>
                 <p><strong>Interests:</strong> ${(p.interests ?? []).join(', ') || '—'}</p>
+                <p><strong>Areas:</strong> ${(p.areas ?? []).join(', ') || '—'}</p>
                 <p><strong>Availability:</strong> ${(p.availability ?? []).join(', ') || '—'}</p>
                 <p><strong>Books:</strong></p>
                 <ul>${books || '<li>—</li>'}</ul>


### PR DESCRIPTION
## Summary
- ensure interests show before areas in the student and teacher profile modals

## Testing
- `mvn test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687888fea80083208a24a965f6aed935