### PR TITLE
Add project deletion and hide table when empty

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
@@ -102,4 +102,17 @@ public class ProjectController {
 
                 return "redirect:/advisor-dashboard";
         }
+
+        @PostMapping("/delete")
+        public String deleteProject(@AuthenticationPrincipal OidcUser oidcUser,
+                                    @RequestParam Long projectId) {
+                User student = userRepository.findByEmail(oidcUser.getEmail()).orElseThrow();
+                Project project = projectRepository.findById(projectId).orElseThrow();
+
+                if (project.getStudent().getId().equals(student.getId())) {
+                        projectRepository.delete(project);
+                }
+
+                return "redirect:/dashboard";
+        }
 }

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -105,22 +105,31 @@
                         </div>
 
                         <div class="tab-pane fade" id="projects-tab-pane" role="tabpanel" aria-labelledby="projects-tab" tabindex="0">
-                                <table class="table">
-                                        <thead>
-                                                <tr>
-                                                        <th>Title</th>
-                                                        <th>Description</th>
-                                                        <th>Status</th>
-                                                </tr>
-                                        </thead>
-                                        <tbody>
-                                                <tr th:each="p : ${studentProjects}">
-                                                        <td th:text="${p.title}">Title</td>
-                                                        <td th:text="${p.description}">Description</td>
-                                                        <td th:text="${p.status}">Status</td>
-                                                </tr>
-                                        </tbody>
-                                </table>
+                                <th:block th:if="${studentProjects != null and !#lists.isEmpty(studentProjects)}">
+                                        <table class="table">
+                                                <thead>
+                                                        <tr>
+                                                                <th>Title</th>
+                                                                <th>Description</th>
+                                                                <th>Status</th>
+                                                                <th></th>
+                                                        </tr>
+                                                </thead>
+                                                <tbody>
+                                                        <tr th:each="p : ${studentProjects}">
+                                                                <td th:text="${p.title}">Title</td>
+                                                                <td th:text="${p.description}">Description</td>
+                                                                <td th:text="${p.status}">Status</td>
+                                                                <td>
+                                                                        <form th:action="@{/project/delete}" method="post" style="display:inline;">
+                                                                                <input type="hidden" name="projectId" th:value="${p.id}" />
+                                                                                <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                                                                        </form>
+                                                                </td>
+                                                        </tr>
+                                                </tbody>
+                                        </table>
+                                </th:block>
                                 <p th:if="${studentProjects == null or #lists.isEmpty(studentProjects)}">No results found.</p>
                                 <a href="/project/new" class="btn btn-outline-primary mt-3">Propose New Project</a>
                         </div>


### PR DESCRIPTION
## Summary
- hide project table headers when list is empty
- add delete button per project row
- handle delete action in `ProjectController`

## Testing
- `mvn test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687889edb19c8320986b5768496d27d8