### PR TITLE
Prevent additional match requests when student already has an advisor

### DIFF
--- a/src/main/java/com/uanl/asesormatch/repository/MatchRepository.java
+++ b/src/main/java/com/uanl/asesormatch/repository/MatchRepository.java
@@ -13,9 +13,11 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 
 	boolean existsByStudentIdAndAdvisorIdAndStatus(Long studentId, Long advisorId, MatchStatus status);
 	
-	boolean existsByStudentIdAndAdvisorId(Long studentId, Long advisorId);
+        boolean existsByStudentIdAndAdvisorId(Long studentId, Long advisorId);
 
-	List<Match> findByAdvisor(User advisor);
+        List<Match> findByAdvisor(User advisor);
 
-	List<Match> findByAdvisorAndStatus(User advisor, MatchStatus accepted);
+        List<Match> findByAdvisorAndStatus(User advisor, MatchStatus accepted);
+
+        boolean existsByStudentIdAndStatus(Long studentId, MatchStatus status);
 }

--- a/src/main/java/com/uanl/asesormatch/service/MatchingService.java
+++ b/src/main/java/com/uanl/asesormatch/service/MatchingService.java
@@ -101,13 +101,18 @@ public class MatchingService {
                 });
         }
 
-	public void requestMatch(Long studentId, Long advisorId, Double score) {
-		User student = userRepository.findById(studentId).orElseThrow(() -> new IllegalArgumentException("student"));
-		User advisor = userRepository.findById(advisorId).orElseThrow(() -> new IllegalArgumentException("advisor"));
+        public void requestMatch(Long studentId, Long advisorId, Double score) {
+                User student = userRepository.findById(studentId).orElseThrow(() -> new IllegalArgumentException("student"));
+                User advisor = userRepository.findById(advisorId).orElseThrow(() -> new IllegalArgumentException("advisor"));
 
-		Match match = new Match();
-		match.setStudent(student);
-		match.setAdvisor(advisor);
+                boolean alreadyAssigned = matchRepository.existsByStudentIdAndStatus(studentId, MatchStatus.ACCEPTED);
+                if (alreadyAssigned) {
+                        throw new IllegalStateException("student already has an accepted match");
+                }
+
+                Match match = new Match();
+                match.setStudent(student);
+                match.setAdvisor(advisor);
 		match.setCompatibilityScore(score);
 		match.setStatus(MatchStatus.PENDING);
 		match.setCreatedAt(LocalDateTime.now());

--- a/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
 class MatchingServiceTests {
@@ -146,5 +147,36 @@ class MatchingServiceTests {
         assertEquals(1, notifications.size());
         String msg = notifications.get(0).getMessage();
         assertEquals("El maestro " + advisor1.getFullName() + " aprob\u00F3 ser tu tutor.", msg);
+    }
+
+    @Test
+    void requestMatchFailsIfAcceptedMatchExists() {
+        User student = new User();
+        student.setFullName("Student Test");
+        student.setEmail("student2@test.com");
+        student.setRole(Role.STUDENT);
+        userRepository.save(student);
+
+        User advisor1 = new User();
+        advisor1.setFullName("Advisor One");
+        advisor1.setEmail("advisor1@test.com");
+        advisor1.setRole(Role.ADVISOR);
+        userRepository.save(advisor1);
+
+        User advisor2 = new User();
+        advisor2.setFullName("Advisor Two");
+        advisor2.setEmail("advisor2@test.com");
+        advisor2.setRole(Role.ADVISOR);
+        userRepository.save(advisor2);
+
+        Match match = new Match();
+        match.setStudent(student);
+        match.setAdvisor(advisor1);
+        match.setCompatibilityScore(0.9);
+        match.setStatus(MatchStatus.ACCEPTED);
+        matchRepository.save(match);
+
+        assertThrows(IllegalStateException.class,
+                () -> matchingService.requestMatch(student.getId(), advisor2.getId(), 0.8));
     }
 }


### PR DESCRIPTION
## Summary
- prevent creation of new match requests if the student already has an accepted match
- expose repository helper `existsByStudentIdAndStatus`
- test requesting a match when the student already has an accepted advisor

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68788eac4dac8320a1afb2cb654fab8d