### PR TITLE
Translate Spanish text in templates

### DIFF
--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -26,7 +26,7 @@
             <div class="col-md-4 mb-3">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">Proyectos completados con los estudiantes</h5>
+                        <h5 class="card-title">Projects completed with students</h5>
                         <p class="display-6" th:text="${completedProjectCount}">0</p>
                     </div>
                 </div>
@@ -70,7 +70,7 @@
                                                 </form>
                                                 <form th:if="${match.status == T(com.uanl.asesormatch.enums.MatchStatus).ACCEPTED}" th:action="@{/project/complete}" method="post" style="display: inline;">
                                                         <input type="hidden" name="matchId" th:value="${match.id}" />
-                                                        <button type="submit" class="btn btn-outline-primary btn-sm">Completado</button>
+                                                        <button type="submit" class="btn btn-outline-primary btn-sm">Completed</button>
                                                 </form>
                                         </td>
 
@@ -97,7 +97,7 @@
                         </tbody>
                 </table>
 
-                <h4 class="mt-5">Proyectos completados con los estudiantes</h4>
+                <h4 class="mt-5">Projects completed with students</h4>
                 <table class="table table-hover">
                         <thead>
                                 <tr>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -177,7 +177,7 @@
             const rows = filtered.map(r => {
                 const percent  = Math.round(r.score * 100);
                 const badge    = r.score > 0.70 ?
-                    ' <span class="badge bg-success ms-2">Este maestro es perfecto para ti</span>' : '';
+                    ' <span class="badge bg-success ms-2">This advisor is perfect for you</span>' : '';
                 const rowClass = r.score > 0.70 ? ' class="table-success"' : '';
                 return `
                 <tr${rowClass}>
@@ -207,7 +207,7 @@
                 </table>`;
 
             if (!hasAboveTen) {
-                return `<div class="alert alert-warning">Por ahora no pudimos encontrar un maestro en base a tu perfil</div>` + table;
+                return `<div class="alert alert-warning">For now we couldn't find an advisor based on your profile</div>` + table;
             }
             return table;
         }

--- a/src/main/resources/templates/edit-profile.html
+++ b/src/main/resources/templates/edit-profile.html
@@ -45,7 +45,7 @@
 			<!-- ─── Books (List<BookDTO>) ──────────────────────────────── -->
 			<h5 class="mt-4 mb-2">Books</h5>
 			<div id="books-container">
-				<!-- pinta los libros ya existentes -->
+				<!-- display existing books -->
 				<th:block th:each="book,stat : *{books}">
 					<div class="book-entry border rounded p-3 position-relative mb-3">
 						<button type="button"
@@ -64,7 +64,7 @@
 				</th:block>
 			</div>
 
-			<!-- plantilla clonable -->
+			<!-- cloneable template -->
 			<template id="book-template">
 				<div class="book-entry border rounded p-3 position-relative mb-3">
 					<button type="button"
@@ -81,7 +81,7 @@
 			<button type="button" class="btn btn-outline-primary mb-3"
 				onclick="addBook()">Add book</button>
 
-			<!-- ─── Campos simples ─────────────────────────────────────── -->
+			<!-- ─── Simple fields ─────────────────────────────────────── -->
                         <div class="mb-3">
                                 <label class="form-label">Level</label>
                                 <input class="form-control" th:field="*{level}" list="level-suggestions" />
@@ -113,7 +113,7 @@
 
 	<!-- ======================  SCRIPTS  ====================== -->
 	<script>
-    /* ——— Tagify -> genera inputs ocultos tipo interests[0] ——— */
+    /* ——— Tagify -> generates hidden inputs like interests[0] ——— */
     function initTagify(visibleId, hiddenWrapperId, initialList, suggestions) {
         const visible = document.getElementById(visibleId);
         const tagify  = new Tagify(visible, {whitelist: suggestions, dropdown: {maxItems: 20, enabled: 0}});
@@ -121,7 +121,7 @@
 
         const wrapper = document.getElementById(hiddenWrapperId);
         const sync = () => {
-            wrapper.innerHTML = '';                                // limpia
+            wrapper.innerHTML = '';                                // clear
             tagify.value.forEach((t, i) => {
                 const h = document.createElement('input');
                 h.type  = 'hidden';
@@ -131,10 +131,10 @@
             });
         };
         tagify.on('add', sync).on('remove', sync).on('edit', sync);
-        sync();                                                   // 1ª vez
+        sync();                                                   // first time
     }
 
-    /* listas iniciales que Thymeleaf inyecta como arrays JS */
+    /* initial lists that Thymeleaf injects as JS arrays */
     const initInterests    = /*[[${profile.interests}]]*/ [];
     const initAreas        = /*[[${profile.areas}]]*/ [];
     const initAvailability = /*[[${profile.availability}]]*/ [];
@@ -146,7 +146,7 @@
     initTagify('areas-input',       'areas-hidden',       initAreas, suggestionsAreas);
     initTagify('availability-input','availability-hidden',initAvailability, suggestionsAvailability);
 
-    /* ——— Books dinámicos ——— */
+    /* ——— Dynamic books ——— */
     let bookIndex = document.querySelectorAll('#books-container .book-entry').length;
 
     function addBook() {


### PR DESCRIPTION
## Summary
- translate all remaining Spanish phrases in dashboard templates
- translate Spanish comments and headings in HTML templates

## Testing
- `mvn test` *(fails: command not found)*
- `apt-get update`
- `apt-get install -y maven` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_687893b35a988320b97c5b269b9e104a