### PR TITLE
Allow new advisor after project completion

### DIFF
--- a/src/main/java/com/uanl/asesormatch/repository/ProjectRepository.java
+++ b/src/main/java/com/uanl/asesormatch/repository/ProjectRepository.java
@@ -18,4 +18,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     java.util.Optional<Project> findByStudentAndAdvisorAndStatus(User student, User advisor, ProjectStatus status);
 
     java.util.List<Project> findByAdvisorAndStatus(User advisor, ProjectStatus status);
+
+    boolean existsByStudentAndStatus(User student, ProjectStatus status);
 }

--- a/src/main/java/com/uanl/asesormatch/service/MatchingService.java
+++ b/src/main/java/com/uanl/asesormatch/service/MatchingService.java
@@ -102,10 +102,10 @@ public class MatchingService {
 		User student = userRepository.findById(studentId).orElseThrow(() -> new IllegalArgumentException("student"));
 		User advisor = userRepository.findById(advisorId).orElseThrow(() -> new IllegalArgumentException("advisor"));
 
-		boolean alreadyAssigned = matchRepository.existsByStudentIdAndStatus(studentId, MatchStatus.ACCEPTED);
-		if (alreadyAssigned) {
-			throw new IllegalStateException("student already has an accepted match");
-		}
+                boolean ongoingProject = projectRepository.existsByStudentAndStatus(student, ProjectStatus.IN_PROGRESS);
+                if (ongoingProject) {
+                        throw new IllegalStateException("student already has an accepted match");
+                }
 
 		Match match = new Match();
 		match.setStudent(student);


### PR DESCRIPTION
## Summary
- only block new matches if the student has a project in progress
- add repository helper `existsByStudentAndStatus`
- update tests to reflect new rule and add coverage when project completed

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687899dd978c8320bb89a963e7b0b284