### PR TITLE
Implement project selection for advisor

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
@@ -62,14 +62,18 @@ public class ProjectController {
 		User advisor = userRepository.findByEmail(oidcUser.getEmail()).orElseThrow();
 		Project project = projectRepository.findById(projectId).orElseThrow();
 
-		boolean hasMatch = matchRepository.existsByStudentIdAndAdvisorIdAndStatus(project.getStudent().getId(),
-				advisor.getId(), MatchStatus.ACCEPTED);
+                boolean hasMatch = matchRepository.existsByStudentIdAndAdvisorIdAndStatus(
+                                project.getStudent().getId(), advisor.getId(), MatchStatus.ACCEPTED);
 
-		if (project.getAdvisor() == null && hasMatch) {
-			project.setAdvisor(advisor);
-			project.setStatus(ProjectStatus.IN_PROGRESS);
-			projectRepository.save(project);
-		}
+                boolean hasActive = projectRepository
+                                .findByStudentAndAdvisorAndStatus(project.getStudent(), advisor, ProjectStatus.IN_PROGRESS)
+                                .isPresent();
+
+                if (project.getAdvisor() == null && hasMatch && !hasActive) {
+                        project.setAdvisor(advisor);
+                        project.setStatus(ProjectStatus.IN_PROGRESS);
+                        projectRepository.save(project);
+                }
 
 		return "redirect:/advisor-dashboard";
 	}

--- a/src/main/java/com/uanl/asesormatch/service/MatchingService.java
+++ b/src/main/java/com/uanl/asesormatch/service/MatchingService.java
@@ -68,26 +68,15 @@ public class MatchingService {
 			m.setStatus(status);
 			matchRepository.save(m);
 
-			if (status == MatchStatus.ACCEPTED) {
-				// Assign first unassigned project from student to advisor
-				var projects = projectRepository.findByStudent(m.getStudent());
-				for (var p : projects) {
-					if (p.getAdvisor() == null) {
-						p.setAdvisor(m.getAdvisor());
-						p.setStatus(ProjectStatus.IN_PROGRESS);
-						projectRepository.save(p);
-						break;
-					}
-				}
-
-				// Cancel other matches for this student
-				var allMatches = matchRepository.findByStudent(m.getStudent());
-				for (var other : allMatches) {
-					if (!other.getId().equals(m.getId()) && other.getStatus() != MatchStatus.REJECTED) {
-						other.setStatus(MatchStatus.REJECTED);
-						matchRepository.save(other);
-					}
-				}
+                        if (status == MatchStatus.ACCEPTED) {
+                                // Cancel other matches for this student
+                                var allMatches = matchRepository.findByStudent(m.getStudent());
+                                for (var other : allMatches) {
+                                        if (!other.getId().equals(m.getId()) && other.getStatus() != MatchStatus.REJECTED) {
+                                                other.setStatus(MatchStatus.REJECTED);
+                                                matchRepository.save(other);
+                                        }
+                                }
 
 				String msg = "El maestro " + m.getAdvisor().getFullName() + " aprob\u00F3 ser tu tutor.";
 				notificationService.notify(m.getStudent(), msg);

--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -82,25 +82,43 @@
 				</tr>
 			</tbody>
 		</table>
-		<h4 class="mt-5">Projects Assigned</h4>
-		<table class="table table-hover">
-			<thead>
-				<tr>
-					<th>Title</th>
-					<th>Student</th>
-					<th>Status</th>
-					<th>Start Date</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr th:each="project : ${projects}">
-					<td th:text="${project.title}">Project Title</td>
-					<td th:text="${project.student.fullName}">Student</td>
-					<td th:text="${project.status}">IN_PROGRESS</td>
-					<td th:text="${#temporals.format(project.startDate, 'dd/MM/yyyy')}">2025-06-28</td>
-				</tr>
-			</tbody>
-		</table>
+                <h4 class="mt-5">Projects Assigned</h4>
+                <table class="table table-hover">
+                        <thead>
+                                <tr>
+                                        <th>Title</th>
+                                        <th>Description</th>
+                                        <th>Student</th>
+                                        <th>Status</th>
+                                        <th>Start Date</th>
+                                        <th>Actions</th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                <tr th:each="p : ${availableProjects}">
+                                        <td th:text="${p.title}">Title</td>
+                                        <td th:text="${p.description}">Description</td>
+                                        <td th:text="${p.student.fullName}">Student</td>
+                                        <td th:text="${p.status}">DRAFT</td>
+                                        <td th:text="${#temporals.format(p.startDate, 'dd/MM/yyyy')}">2025-06-28</td>
+                                        <td>
+                                                <form th:if="${p.advisor == null and !#lists.contains(blockedStudentIds, p.student.id)}" th:action="@{/project/assign}" method="post" style="display:inline;">
+                                                        <input type="hidden" name="projectId" th:value="${p.id}" />
+                                                        <button type="submit" class="btn btn-primary btn-sm">Accept</button>
+                                                </form>
+                                                <span th:if="${#lists.contains(blockedStudentIds, p.student.id)}" class="text-muted">Blocked</span>
+                                        </td>
+                                </tr>
+                                <tr th:each="p : ${projects}">
+                                        <td th:text="${p.title}">Title</td>
+                                        <td th:text="${p.description}">Description</td>
+                                        <td th:text="${p.student.fullName}">Student</td>
+                                        <td th:text="${p.status}">IN_PROGRESS</td>
+                                        <td th:text="${#temporals.format(p.startDate, 'dd/MM/yyyy')}">2025-06-28</td>
+                                        <td></td>
+                                </tr>
+                        </tbody>
+                </table>
 
 		<h4 class="mt-5">Projects completed with students</h4>
 		<table class="table table-hover">

--- a/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
@@ -229,4 +229,39 @@ class MatchingServiceTests {
                 List<Match> matches = matchRepository.findAll();
                 assertEquals(2, matches.size());
         }
+
+        @Test
+        void acceptingMatchDoesNotAssignProjectAutomatically() {
+                User student = new User();
+                student.setFullName("Student Test");
+                student.setEmail("student4@test.com");
+                student.setRole(Role.STUDENT);
+                userRepository.save(student);
+
+                User advisor = new User();
+                advisor.setFullName("Advisor");
+                advisor.setEmail("advisor4@test.com");
+                advisor.setRole(Role.ADVISOR);
+                userRepository.save(advisor);
+
+                Project project = new Project();
+                project.setTitle("P1");
+                project.setDescription("D1");
+                project.setStatus(ProjectStatus.DRAFT);
+                project.setStudent(student);
+                projectRepository.save(project);
+
+                Match match = new Match();
+                match.setStudent(student);
+                match.setAdvisor(advisor);
+                match.setCompatibilityScore(0.5);
+                match.setStatus(MatchStatus.PENDING);
+                matchRepository.save(match);
+
+                matchingService.updateMatchStatus(match.getId(), MatchStatus.ACCEPTED);
+
+                Project reloaded = projectRepository.findById(project.getId()).orElseThrow();
+                assertNull(reloaded.getAdvisor());
+                assertEquals(ProjectStatus.DRAFT, reloaded.getStatus());
+        }
 }

--- a/src/test/java/com/uanl/asesormatch/service/ProjectAssignmentTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/ProjectAssignmentTests.java
@@ -1,0 +1,111 @@
+package com.uanl.asesormatch.service;
+
+import com.uanl.asesormatch.entity.Match;
+import com.uanl.asesormatch.entity.Project;
+import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.enums.MatchStatus;
+import com.uanl.asesormatch.enums.ProjectStatus;
+import com.uanl.asesormatch.enums.Role;
+import com.uanl.asesormatch.repository.MatchRepository;
+import com.uanl.asesormatch.repository.ProjectRepository;
+import com.uanl.asesormatch.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class ProjectAssignmentTests {
+    @Autowired
+    private ProjectRepository projectRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private MatchRepository matchRepository;
+
+    private User student;
+    private User advisor;
+
+    @BeforeEach
+    void setup() {
+        student = new User();
+        student.setFullName("Student");
+        student.setEmail("s@test.com");
+        student.setRole(Role.STUDENT);
+        userRepository.save(student);
+
+        advisor = new User();
+        advisor.setFullName("Advisor");
+        advisor.setEmail("a@test.com");
+        advisor.setRole(Role.ADVISOR);
+        userRepository.save(advisor);
+
+        Match match = new Match();
+        match.setStudent(student);
+        match.setAdvisor(advisor);
+        match.setCompatibilityScore(0.8);
+        match.setStatus(MatchStatus.ACCEPTED);
+        matchRepository.save(match);
+    }
+
+    @Test
+    void cannotAssignSecondProjectIfOneInProgress() {
+        Project p1 = new Project();
+        p1.setTitle("P1");
+        p1.setDescription("D1");
+        p1.setStudent(student);
+        p1.setAdvisor(advisor);
+        p1.setStatus(ProjectStatus.IN_PROGRESS);
+        projectRepository.save(p1);
+
+        Project p2 = new Project();
+        p2.setTitle("P2");
+        p2.setDescription("D2");
+        p2.setStudent(student);
+        p2.setStatus(ProjectStatus.DRAFT);
+        projectRepository.save(p2);
+
+        boolean hasMatch = matchRepository.existsByStudentIdAndAdvisorIdAndStatus(student.getId(), advisor.getId(), MatchStatus.ACCEPTED);
+        boolean hasActive = projectRepository.findByStudentAndAdvisorAndStatus(student, advisor, ProjectStatus.IN_PROGRESS).isPresent();
+        if (p2.getAdvisor() == null && hasMatch && !hasActive) {
+            p2.setAdvisor(advisor);
+            p2.setStatus(ProjectStatus.IN_PROGRESS);
+            projectRepository.save(p2);
+        }
+
+        Project reloaded = projectRepository.findById(p2.getId()).orElseThrow();
+        assertNull(reloaded.getAdvisor());
+    }
+
+    @Test
+    void assignAllowedAfterCompletion() {
+        Project p1 = new Project();
+        p1.setTitle("P1");
+        p1.setDescription("D1");
+        p1.setStudent(student);
+        p1.setAdvisor(advisor);
+        p1.setStatus(ProjectStatus.COMPLETED);
+        projectRepository.save(p1);
+
+        Project p2 = new Project();
+        p2.setTitle("P2");
+        p2.setDescription("D2");
+        p2.setStudent(student);
+        p2.setStatus(ProjectStatus.DRAFT);
+        projectRepository.save(p2);
+
+        boolean hasMatch = matchRepository.existsByStudentIdAndAdvisorIdAndStatus(student.getId(), advisor.getId(), MatchStatus.ACCEPTED);
+        boolean hasActive = projectRepository.findByStudentAndAdvisorAndStatus(student, advisor, ProjectStatus.IN_PROGRESS).isPresent();
+        if (p2.getAdvisor() == null && hasMatch && !hasActive) {
+            p2.setAdvisor(advisor);
+            p2.setStatus(ProjectStatus.IN_PROGRESS);
+            projectRepository.save(p2);
+        }
+
+        Project reloaded = projectRepository.findById(p2.getId()).orElseThrow();
+        assertEquals(advisor.getId(), reloaded.getAdvisor().getId());
+        assertEquals(ProjectStatus.IN_PROGRESS, reloaded.getStatus());
+    }
+}


### PR DESCRIPTION
## Summary
- stop automatic project assignment when advisor accepts a match
- prevent multiple active projects per student/advisor
- display available student projects after match acceptance
- add ability to accept a specific project from dashboard
- add tests for project assignment rules

## Testing
- `mvn test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6879a52fb6d48320af97c09cb873fd3f