### PR TITLE
Fix completed matches filtering

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
@@ -69,7 +69,11 @@ public class ProjectController {
                                 .findByStudentAndAdvisorAndStatus(project.getStudent(), advisor, ProjectStatus.IN_PROGRESS)
                                 .isPresent();
 
-                if (project.getAdvisor() == null && hasMatch && !hasActive) {
+                boolean hasCompleted = projectRepository
+                                .findByStudentAndAdvisorAndStatus(project.getStudent(), advisor, ProjectStatus.COMPLETED)
+                                .isPresent();
+
+                if (project.getAdvisor() == null && hasMatch && !hasActive && !hasCompleted) {
                         project.setAdvisor(advisor);
                         project.setStatus(ProjectStatus.IN_PROGRESS);
                         projectRepository.save(project);

--- a/src/main/java/com/uanl/asesormatch/controller/advisor/AdvisorDashboardController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/advisor/AdvisorDashboardController.java
@@ -52,7 +52,13 @@ public class AdvisorDashboardController {
                         .filter(p -> p.getStatus() != ProjectStatus.COMPLETED)
                         .toList();
 
-        var acceptedMatches = matchRepository.findByAdvisorAndStatus(advisor, MatchStatus.ACCEPTED);
+        var acceptedMatches = matchRepository.findByAdvisorAndStatus(advisor, MatchStatus.ACCEPTED)
+                        .stream()
+                        .filter(m -> projectRepository
+                                        .findByStudentAndAdvisorAndStatus(m.getStudent(), advisor,
+                                                        ProjectStatus.COMPLETED)
+                                        .isEmpty())
+                        .toList();
         java.util.List<com.uanl.asesormatch.entity.Project> available = new java.util.ArrayList<>();
         java.util.Set<Long> blocked = new java.util.HashSet<>();
         for (var p : assignedProjects) {


### PR DESCRIPTION
## Summary
- filter out matches with completed projects when listing available projects
- block project assignment if a completed project exists for a match

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_6879b75f23188320bebb8c921891cdfb