### PR TITLE
Enable per project completion

### DIFF
--- a/src/main/java/com/uanl/asesormatch/entity/Match.java
+++ b/src/main/java/com/uanl/asesormatch/entity/Match.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 import java.time.LocalDateTime;
 
@@ -34,7 +35,10 @@ public class Match {
 	@Enumerated(EnumType.STRING)
 	private MatchStatus status;
 
-	private String algorithmUsed;
+        private String algorithmUsed;
+
+        @Transient
+        private boolean allProjectsCompleted;
 
 	public Long getId() {
 		return id;
@@ -88,7 +92,15 @@ public class Match {
 		return algorithmUsed;
 	}
 
-	public void setAlgorithmUsed(String algorithmUsed) {
-		this.algorithmUsed = algorithmUsed;
-	}
+        public void setAlgorithmUsed(String algorithmUsed) {
+                this.algorithmUsed = algorithmUsed;
+        }
+
+        public boolean isAllProjectsCompleted() {
+                return allProjectsCompleted;
+        }
+
+        public void setAllProjectsCompleted(boolean allProjectsCompleted) {
+                this.allProjectsCompleted = allProjectsCompleted;
+        }
 }

--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -57,23 +57,23 @@
 							th:data-student-id="${match.student.id}" title="View profile">
 							<i class="bi bi-eye"></i>
 						</button>
-						<form th:action="@{/match/decision}" method="post"
-							style="display: inline;">
+                                                <form th:action="@{/match/decision}" method="post" class="decision-form"
+                                                        style="display: inline;">
 							<input type="hidden" name="matchId" th:value="${match.id}" /> <input
 								type="hidden" name="action" value="ACCEPTED" />
 							<button type="submit" class="btn btn-success btn-sm"
 								th:disabled="${match.status.name() != 'PENDING'}">Accept</button>
 						</form>
-						<form th:action="@{/match/decision}" method="post"
-							style="display: inline;">
+                                                <form th:action="@{/match/decision}" method="post" class="decision-form"
+                                                        style="display: inline;">
 							<input type="hidden" name="matchId" th:value="${match.id}" /> <input
 								type="hidden" name="action" value="REJECTED" />
 							<button type="submit" class="btn btn-danger btn-sm"
 								th:disabled="${match.status.name() != 'PENDING'}">Reject</button>
 						</form>
-						<form th:if="${match.status.name() == 'ACCEPTED'}"
-							th:action="@{/project/complete}" method="post"
-							style="display: inline;">
+                                                <form th:if="${match.status.name() == 'ACCEPTED' and match.allProjectsCompleted}"
+                                                        th:action="@{/project/complete}" method="post"
+                                                        style="display: inline;">
 							<input type="hidden" name="matchId" th:value="${match.id}" />
 							<button type="submit" class="btn btn-outline-primary btn-sm">Completed</button>
 						</form>
@@ -115,7 +115,12 @@
                                         <td th:text="${p.student.fullName}">Student</td>
                                         <td th:text="${p.status}">IN_PROGRESS</td>
                                         <td th:text="${#temporals.format(p.startDate, 'dd/MM/yyyy')}">2025-06-28</td>
-                                        <td></td>
+                                        <td>
+                                                <form th:if="${p.status.name() == 'IN_PROGRESS'}" th:action="@{/project/complete-project}" method="post" style="display:inline;">
+                                                        <input type="hidden" name="projectId" th:value="${p.id}" />
+                                                        <button type="submit" class="btn btn-outline-primary btn-sm">Completed</button>
+                                                </form>
+                                        </td>
                                 </tr>
                         </tbody>
                 </table>
@@ -196,6 +201,13 @@
                         `<p class="text-danger">Unable to load profile (status ${e}).</p>`;
                 }
                 mod.show();
+            });
+        });
+
+        document.querySelectorAll('.decision-form').forEach(form => {
+            form.addEventListener('submit', () => {
+                const td = form.closest('td');
+                td.querySelectorAll('.decision-form').forEach(f => f.style.display = 'none');
             });
         });
 


### PR DESCRIPTION
## Summary
- track when all projects from a match are completed
- allow assigning new projects after previous ones finish
- add endpoint to mark a specific project completed
- show completion controls per project on advisor dashboard
- hide match decision buttons after click

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6879beaa98a8832094fe3dc5343df6ea