### PR TITLE
Implement COMPLETED match state

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
@@ -104,8 +104,12 @@ public class ProjectController {
         @PostMapping("/complete")
         public String completeProject(@RequestParam Long matchId) {
                 var match = matchRepository.findById(matchId).orElseThrow();
+                match.setStatus(MatchStatus.COMPLETED);
+                matchRepository.save(match);
+
                 var optProject = projectRepository.findByStudentAndAdvisorAndStatus(
                                 match.getStudent(), match.getAdvisor(), ProjectStatus.IN_PROGRESS);
+
                 optProject.ifPresent(p -> {
                         p.setStatus(ProjectStatus.COMPLETED);
                         projectRepository.save(p);

--- a/src/main/java/com/uanl/asesormatch/enums/MatchStatus.java
+++ b/src/main/java/com/uanl/asesormatch/enums/MatchStatus.java
@@ -1,5 +1,8 @@
 package com.uanl.asesormatch.enums;
 
 public enum MatchStatus {
-	PENDING, ACCEPTED, REJECTED
+        PENDING,
+        ACCEPTED,
+        COMPLETED,
+        REJECTED
 }


### PR DESCRIPTION
## Summary
- add `COMPLETED` value to `MatchStatus`
- update completion controller to set match status and close active projects automatically

## Testing
- `mvnw -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6879c59e58448320a4da97ebb06d864a