### PR TITLE
Show latest completed matches on advisor dashboard

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/advisor/AdvisorDashboardController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/advisor/AdvisorDashboardController.java
@@ -40,7 +40,10 @@ public class AdvisorDashboardController {
         int matchCount = matchRepository.findByAdvisor(advisor).size();
         int projectCount = projectRepository.findByAdvisor(advisor).size();
 
-        var matches = matchRepository.findByAdvisor(advisor);
+        var matches = matchRepository.findByAdvisor(advisor)
+                        .stream()
+                        .filter(m -> m.getStatus() != MatchStatus.COMPLETED)
+                        .toList();
         for (var m : matches) {
                 boolean noneActive = projectRepository
                                 .findByStudentAndAdvisorAndStatus(m.getStudent(), advisor,
@@ -48,6 +51,9 @@ public class AdvisorDashboardController {
                                 .isEmpty();
                 m.setAllProjectsCompleted(noneActive);
         }
+
+        var latestCompletedMatches = matchRepository
+                        .findTop5ByAdvisorAndStatusOrderByCreatedAtDesc(advisor, MatchStatus.COMPLETED);
 
         var completedProjects = projectRepository.findByAdvisorAndStatus(advisor, ProjectStatus.COMPLETED);
 
@@ -82,6 +88,7 @@ public class AdvisorDashboardController {
         model.addAttribute("completedProjectCount", completedProjectCount);
         model.addAttribute("advisor", advisor);
         model.addAttribute("matches", matches);
+        model.addAttribute("latestCompletedMatches", latestCompletedMatches);
         model.addAttribute("projects", assignedProjects);
         model.addAttribute("availableProjects", available);
         model.addAttribute("blockedStudentIds", blocked);

--- a/src/main/java/com/uanl/asesormatch/repository/MatchRepository.java
+++ b/src/main/java/com/uanl/asesormatch/repository/MatchRepository.java
@@ -19,5 +19,7 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 
         List<Match> findByAdvisorAndStatus(User advisor, MatchStatus accepted);
 
+        List<Match> findTop5ByAdvisorAndStatusOrderByCreatedAtDesc(User advisor, MatchStatus status);
+
         boolean existsByStudentIdAndStatus(Long studentId, MatchStatus status);
 }

--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -81,7 +81,26 @@
 
 				</tr>
 			</tbody>
-		</table>
+                </table>
+
+                <h4 class="mt-5">Latest Completed Matches</h4>
+                <table class="table table-striped">
+                        <thead>
+                                <tr>
+                                        <th>Student</th>
+                                        <th>Score</th>
+                                        <th>Date</th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                <tr th:each="m : ${latestCompletedMatches}">
+                                        <td th:text="${m.student.fullName}">Student Name</td>
+                                        <td th:text="${T(java.lang.Math).round(m.compatibilityScore * 100)} + '%'">0%</td>
+                                        <td th:text="${#temporals.format(m.createdAt, 'dd/MM/yyyy')}">date</td>
+                                </tr>
+                        </tbody>
+                </table>
+
                 <h4 class="mt-5">Projects Assigned</h4>
                 <table class="table table-hover">
                         <thead>


### PR DESCRIPTION
## Summary
- filter completed matches out of 'Matches Assigned to You'
- fetch last five completed matches for advisors
- display these matches in new table on advisor dashboard

## Testing
- `mvn test` *(fails: cannot download Maven deps)*

------
https://chatgpt.com/codex/tasks/task_e_6879c776b60c832083e0c92843824424