### PR TITLE
Handle repeated match requests

### DIFF
--- a/src/main/java/com/uanl/asesormatch/repository/MatchRepository.java
+++ b/src/main/java/com/uanl/asesormatch/repository/MatchRepository.java
@@ -11,7 +11,9 @@ import com.uanl.asesormatch.enums.MatchStatus;
 public interface MatchRepository extends JpaRepository<Match, Long> {
 	List<Match> findByStudent(User student);
 
-	boolean existsByStudentIdAndAdvisorIdAndStatus(Long studentId, Long advisorId, MatchStatus status);
+        boolean existsByStudentIdAndAdvisorIdAndStatus(Long studentId, Long advisorId, MatchStatus status);
+
+        java.util.Optional<Match> findByStudentIdAndAdvisorId(Long studentId, Long advisorId);
 	
         boolean existsByStudentIdAndAdvisorId(Long studentId, Long advisorId);
 

--- a/src/main/java/com/uanl/asesormatch/service/MatchingService.java
+++ b/src/main/java/com/uanl/asesormatch/service/MatchingService.java
@@ -87,22 +87,28 @@ public class MatchingService {
 		});
 	}
 
-	public void requestMatch(Long studentId, Long advisorId, Double score) {
-		User student = userRepository.findById(studentId).orElseThrow(() -> new IllegalArgumentException("student"));
-		User advisor = userRepository.findById(advisorId).orElseThrow(() -> new IllegalArgumentException("advisor"));
+        public void requestMatch(Long studentId, Long advisorId, Double score) {
+                User student = userRepository.findById(studentId)
+                                .orElseThrow(() -> new IllegalArgumentException("student"));
+                User advisor = userRepository.findById(advisorId)
+                                .orElseThrow(() -> new IllegalArgumentException("advisor"));
 
                 boolean ongoingProject = projectRepository.existsByStudentAndStatus(student, ProjectStatus.IN_PROGRESS);
                 if (ongoingProject) {
                         throw new IllegalStateException("student already has an accepted match");
                 }
 
-		Match match = new Match();
-		match.setStudent(student);
-		match.setAdvisor(advisor);
-		match.setCompatibilityScore(score);
-		match.setStatus(MatchStatus.PENDING);
-		match.setCreatedAt(LocalDateTime.now());
+                Match match = matchRepository.findByStudentIdAndAdvisorId(studentId, advisorId).orElse(null);
+                if (match == null) {
+                        match = new Match();
+                        match.setStudent(student);
+                        match.setAdvisor(advisor);
+                }
 
-		matchRepository.save(match);
+                match.setCompatibilityScore(score);
+                match.setStatus(MatchStatus.PENDING);
+                match.setCreatedAt(LocalDateTime.now());
+
+                matchRepository.save(match);
 	}
 }

--- a/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
@@ -45,7 +45,7 @@ class MatchingServiceTests {
 	}
 
 	@Test
-	void requestMatchPersistsPendingMatch() {
+        void requestMatchPersistsPendingMatch() {
 		User student = new User();
 		student.setFullName("Student Test");
 		student.setEmail("student@test.com");
@@ -188,6 +188,35 @@ class MatchingServiceTests {
 
                 assertThrows(IllegalStateException.class,
                                 () -> matchingService.requestMatch(student.getId(), advisor2.getId(), 0.8));
+        }
+
+        @Test
+        void requestMatchUpdatesExistingRecordWhenMatchingAgain() {
+                User student = new User();
+                student.setFullName("Student Test");
+                student.setEmail("studentre@test.com");
+                student.setRole(Role.STUDENT);
+                userRepository.save(student);
+
+                User advisor = new User();
+                advisor.setFullName("Advisor Test");
+                advisor.setEmail("advisorre@test.com");
+                advisor.setRole(Role.ADVISOR);
+                userRepository.save(advisor);
+
+                matchingService.requestMatch(student.getId(), advisor.getId(), 0.5);
+
+                Match existing = matchRepository.findAll().get(0);
+                existing.setStatus(MatchStatus.REJECTED);
+                matchRepository.save(existing);
+
+                matchingService.requestMatch(student.getId(), advisor.getId(), 0.9);
+
+                List<Match> persisted = matchRepository.findAll();
+                assertEquals(1, persisted.size());
+                Match match = persisted.get(0);
+                assertEquals(MatchStatus.PENDING, match.getStatus());
+                assertEquals(0.9, match.getCompatibilityScore());
         }
 
         @Test


### PR DESCRIPTION
## Summary
- update match repository with search by student and advisor
- reuse existing match record when requesting a match again
- test repeated match updates the existing row

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org...)*

------
https://chatgpt.com/codex/tasks/task_e_6879c9ad23f48320a5ec057f1d42ece9