### PR TITLE
Fix bootstrap script load order

### DIFF
--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -164,7 +164,8 @@
 		<div th:replace="~{fragments/advisorFragments :: profileModal}"></div>
 		<div th:replace="~{fragments/advisorFragments :: feedbackModal}"></div>
 	</div>
-	<script>
+        <script>
+        document.addEventListener('DOMContentLoaded', function() {
         function buildStudentProfileHTML(user) {
             const p = user.profile ?? {};
             const books = (p.books ?? []).map(b =>
@@ -235,6 +236,7 @@
             document.getElementById('feedbackMatchId').value = params.get('feedbackMatchId');
             new bootstrap.Modal('#feedbackModal').show();
         }
+        });
         </script>
 </body>
 </html>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -196,7 +196,8 @@
 		<div th:replace="~{fragments/advisorFragments :: matchModal}"></div>
 		<div th:replace="~{fragments/advisorFragments :: feedbackModal}"></div>
 	</div>
-	<script>
+        <script>
+        document.addEventListener('DOMContentLoaded', function() {
         /* ------------- utils ---------------- */
         function buildProfileHTML(user) {
             const p = user.profile ?? {};
@@ -343,6 +344,7 @@
             document.getElementById('feedbackMatchId').value = params.get('feedbackMatchId');
             new bootstrap.Modal('#feedbackModal').show();
         }
+        });
         </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- prevent 'bootstrap is not defined' errors on dashboard pages

## Testing
- `./mvnw -q test` *(fails: failed to fetch maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6879d32d4384832096d931056dec9226