### PR TITLE
Add feedback modal context info

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/MatchInfoController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/MatchInfoController.java
@@ -1,0 +1,47 @@
+package com.uanl.asesormatch.controller;
+
+import com.uanl.asesormatch.dto.MatchInfoDTO;
+import com.uanl.asesormatch.entity.Match;
+import com.uanl.asesormatch.entity.Project;
+import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.enums.ProjectStatus;
+import com.uanl.asesormatch.repository.MatchRepository;
+import com.uanl.asesormatch.repository.ProjectRepository;
+import com.uanl.asesormatch.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/matches")
+public class MatchInfoController {
+    private final MatchRepository matchRepo;
+    private final ProjectRepository projectRepo;
+    private final UserRepository userRepo;
+
+    public MatchInfoController(MatchRepository matchRepo, ProjectRepository projectRepo, UserRepository userRepo) {
+        this.matchRepo = matchRepo;
+        this.projectRepo = projectRepo;
+        this.userRepo = userRepo;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<MatchInfoDTO> info(@AuthenticationPrincipal OidcUser oidcUser, @PathVariable Long id) {
+        User current = userRepo.findByEmail(oidcUser.getEmail()).orElseThrow();
+        Match match = matchRepo.findById(id).orElse(null);
+        if (match == null) {
+            return ResponseEntity.notFound().build();
+        }
+        User other = current.getId().equals(match.getStudent().getId()) ? match.getAdvisor() : match.getStudent();
+        Project project = projectRepo
+                .findByStudentAndAdvisorAndStatus(match.getStudent(), match.getAdvisor(), ProjectStatus.COMPLETED)
+                .orElse(null);
+        String title = project != null ? project.getTitle() : "";
+        MatchInfoDTO dto = new MatchInfoDTO(match.getId(), other.getFullName(), title);
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/src/main/java/com/uanl/asesormatch/dto/MatchInfoDTO.java
+++ b/src/main/java/com/uanl/asesormatch/dto/MatchInfoDTO.java
@@ -1,0 +1,3 @@
+package com.uanl.asesormatch.dto;
+
+public record MatchInfoDTO(Long id, String otherUserName, String projectTitle) {}

--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -233,8 +233,17 @@
 
         const params = new URLSearchParams(window.location.search);
         if (params.has('feedbackMatchId')) {
-            document.getElementById('feedbackMatchId').value = params.get('feedbackMatchId');
-            new bootstrap.Modal('#feedbackModal').show();
+            const id = params.get('feedbackMatchId');
+            document.getElementById('feedbackMatchId').value = id;
+            fetch(`/api/matches/${id}`)
+                .then(r => r.ok ? r.json() : null)
+                .then(data => {
+                    if (data) {
+                        document.getElementById('feedbackOtherName').textContent = data.otherUserName;
+                        document.getElementById('feedbackProjectTitle').textContent = data.projectTitle;
+                    }
+                    new bootstrap.Modal('#feedbackModal').show();
+                });
         }
         });
         </script>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -341,8 +341,17 @@
 
         const params = new URLSearchParams(window.location.search);
         if (params.has('feedbackMatchId')) {
-            document.getElementById('feedbackMatchId').value = params.get('feedbackMatchId');
-            new bootstrap.Modal('#feedbackModal').show();
+            const id = params.get('feedbackMatchId');
+            document.getElementById('feedbackMatchId').value = id;
+            fetch(`/api/matches/${id}`)
+                .then(r => r.ok ? r.json() : null)
+                .then(data => {
+                    if (data) {
+                        document.getElementById('feedbackOtherName').textContent = data.otherUserName;
+                        document.getElementById('feedbackProjectTitle').textContent = data.projectTitle;
+                    }
+                    new bootstrap.Modal('#feedbackModal').show();
+                });
         }
         });
         </script>

--- a/src/main/resources/templates/fragments/advisorFragments.html
+++ b/src/main/resources/templates/fragments/advisorFragments.html
@@ -95,7 +95,13 @@
 							<h5 class="modal-title">Feedback</h5>
 							<button type="button" class="btn-close" data-bs-dismiss="modal"></button>
 						</div>
-						<div class="modal-body">
+                                                <div class="modal-body">
+                                                        <p class="small text-muted mb-3">
+                                                                Estos comentarios nos ayudaran a mejorar nuestro sistema de emparejamiento.
+                                                                ¿cómo te sentiste de trabajar con
+                                                                <strong id="feedbackOtherName"></strong>
+                                                                en el proyecto <strong id="feedbackProjectTitle"></strong>?
+                                                        </p>
                                                         <div class="mb-3">
                                                                 <label class="form-label d-block" for="rating">Rating</label>
                                                                 <input type="hidden" name="rating" id="rating" value="0" />


### PR DESCRIPTION
## Summary
- show helpful text in feedback modal
- include name and project title using new `/api/matches/{id}` endpoint
- display fetched info in dashboard and advisor dashboard

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879d5594fc88320a6815904309f0d03