### PR TITLE
Implement separate feedback for match participants

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/FeedbackController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/FeedbackController.java
@@ -43,6 +43,8 @@ public class FeedbackController {
             Feedback fb = new Feedback();
             fb.setMatch(match);
             fb.setFromUser(user);
+            fb.setToUser(user.getId().equals(match.getStudent().getId()) ? match.getAdvisor() : match.getStudent());
+            fb.setCreatedAt(java.time.LocalDateTime.now());
             fb.setRating(rating);
             fb.setComment(comment);
             feedbackRepo.save(fb);

--- a/src/main/java/com/uanl/asesormatch/controller/MatchInfoController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/MatchInfoController.java
@@ -8,6 +8,7 @@ import com.uanl.asesormatch.enums.ProjectStatus;
 import com.uanl.asesormatch.repository.MatchRepository;
 import com.uanl.asesormatch.repository.ProjectRepository;
 import com.uanl.asesormatch.repository.UserRepository;
+import com.uanl.asesormatch.repository.FeedbackRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -22,11 +23,14 @@ public class MatchInfoController {
     private final MatchRepository matchRepo;
     private final ProjectRepository projectRepo;
     private final UserRepository userRepo;
+    private final FeedbackRepository feedbackRepo;
 
-    public MatchInfoController(MatchRepository matchRepo, ProjectRepository projectRepo, UserRepository userRepo) {
+    public MatchInfoController(MatchRepository matchRepo, ProjectRepository projectRepo, UserRepository userRepo,
+                               FeedbackRepository feedbackRepo) {
         this.matchRepo = matchRepo;
         this.projectRepo = projectRepo;
         this.userRepo = userRepo;
+        this.feedbackRepo = feedbackRepo;
     }
 
     @GetMapping("/{id}")
@@ -41,7 +45,18 @@ public class MatchInfoController {
                 .findByStudentAndAdvisorAndStatus(match.getStudent(), match.getAdvisor(), ProjectStatus.COMPLETED)
                 .orElse(null);
         String title = project != null ? project.getTitle() : "";
-        MatchInfoDTO dto = new MatchInfoDTO(match.getId(), other.getFullName(), title);
+        var myFb = feedbackRepo.findByMatchAndFromUser(match, current).orElse(null);
+        var otherFb = feedbackRepo.findByMatchAndFromUser(match, other).orElse(null);
+
+        MatchInfoDTO dto = new MatchInfoDTO(
+                match.getId(),
+                other.getFullName(),
+                title,
+                myFb != null ? myFb.getRating() : null,
+                myFb != null ? myFb.getComment() : null,
+                otherFb != null ? otherFb.getRating() : null,
+                otherFb != null ? otherFb.getComment() : null
+        );
         return ResponseEntity.ok(dto);
     }
 }

--- a/src/main/java/com/uanl/asesormatch/dto/MatchInfoDTO.java
+++ b/src/main/java/com/uanl/asesormatch/dto/MatchInfoDTO.java
@@ -1,3 +1,6 @@
 package com.uanl.asesormatch.dto;
 
-public record MatchInfoDTO(Long id, String otherUserName, String projectTitle) {}
+public record MatchInfoDTO(Long id, String otherUserName, String projectTitle,
+                           Integer myRating, String myComment,
+                           Integer otherRating, String otherComment) {
+}

--- a/src/main/java/com/uanl/asesormatch/entity/Feedback.java
+++ b/src/main/java/com/uanl/asesormatch/entity/Feedback.java
@@ -1,5 +1,7 @@
 package com.uanl.asesormatch.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.*;
 
 @Entity
@@ -14,6 +16,11 @@ public class Feedback {
 
     @ManyToOne
     private User fromUser;
+
+    @ManyToOne
+    private User toUser;
+
+    private LocalDateTime createdAt;
 
     private Integer rating;
 
@@ -42,6 +49,22 @@ public class Feedback {
 
     public void setFromUser(User fromUser) {
         this.fromUser = fromUser;
+    }
+
+    public User getToUser() {
+        return toUser;
+    }
+
+    public void setToUser(User toUser) {
+        this.toUser = toUser;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
     }
 
     public Integer getRating() {

--- a/src/main/java/com/uanl/asesormatch/repository/FeedbackRepository.java
+++ b/src/main/java/com/uanl/asesormatch/repository/FeedbackRepository.java
@@ -8,4 +8,6 @@ import com.uanl.asesormatch.entity.User;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     boolean existsByMatchAndFromUser(Match match, User fromUser);
+
+    java.util.Optional<Feedback> findByMatchAndFromUser(Match match, User fromUser);
 }

--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -247,8 +247,7 @@
                 .then(r => r.ok ? r.json() : null)
                 .then(data => {
                     if (data) {
-                        document.getElementById('feedbackOtherName').textContent = data.otherUserName;
-                        document.getElementById('feedbackProjectTitle').textContent = data.projectTitle;
+                        populateFeedbackModal(data);
                     }
                     new bootstrap.Modal('#feedbackModal').show();
                 });

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -355,8 +355,7 @@
                 .then(r => r.ok ? r.json() : null)
                 .then(data => {
                     if (data) {
-                        document.getElementById('feedbackOtherName').textContent = data.otherUserName;
-                        document.getElementById('feedbackProjectTitle').textContent = data.projectTitle;
+                        populateFeedbackModal(data);
                     }
                     new bootstrap.Modal('#feedbackModal').show();
                 });

--- a/src/main/resources/templates/fragments/advisorFragments.html
+++ b/src/main/resources/templates/fragments/advisorFragments.html
@@ -102,23 +102,34 @@
                                                                 <strong id="feedbackOtherName"></strong>
                                                                 en el proyecto <strong id="feedbackProjectTitle"></strong>?
                                                         </p>
-                                                        <div class="mb-3">
-                                                                <label class="form-label d-block" for="rating">Rating</label>
-                                                                <input type="hidden" name="rating" id="rating" value="0" />
-                                                                <span class="rating-stars">
-                                                                        <i class="bi bi-star fs-3 star text-secondary" data-value="1"></i>
-                                                                        <i class="bi bi-star fs-3 star text-secondary" data-value="2"></i>
-                                                                        <i class="bi bi-star fs-3 star text-secondary" data-value="3"></i>
-                                                                        <i class="bi bi-star fs-3 star text-secondary" data-value="4"></i>
-                                                                        <i class="bi bi-star fs-3 star text-secondary" data-value="5"></i>
-                                                                </span>
+                                                        <div id="otherFeedback" class="border rounded p-2 mb-3 d-none">
+                                                                <h6 class="fw-bold mb-1" id="otherFeedbackName"></h6>
+                                                                <p class="mb-1"><strong>Rating:</strong> <span id="otherRating"></span></p>
+                                                                <p class="mb-0" id="otherComment"></p>
                                                         </div>
-							<div class="mb-3">
-								<label class="form-label" for="comment">Comment</label>
-								<textarea class="form-control" id="comment" name="comment"
-									rows="3"></textarea>
-							</div>
-						</div>
+                                                        <div id="myFeedbackDisplay" class="border rounded p-2 mb-3 d-none">
+                                                                <h6 class="fw-bold mb-1">Tu feedback</h6>
+                                                                <p class="mb-1"><strong>Rating:</strong> <span id="myRating"></span></p>
+                                                                <p class="mb-0" id="myComment"></p>
+                                                        </div>
+                                                        <div id="myFeedbackForm">
+                                                                <div class="mb-3">
+                                                                        <label class="form-label d-block" for="rating">Rating</label>
+                                                                        <input type="hidden" name="rating" id="rating" value="0" />
+                                                                        <span class="rating-stars">
+                                                                                <i class="bi bi-star fs-3 star text-secondary" data-value="1"></i>
+                                                                                <i class="bi bi-star fs-3 star text-secondary" data-value="2"></i>
+                                                                                <i class="bi bi-star fs-3 star text-secondary" data-value="3"></i>
+                                                                                <i class="bi bi-star fs-3 star text-secondary" data-value="4"></i>
+                                                                                <i class="bi bi-star fs-3 star text-secondary" data-value="5"></i>
+                                                                        </span>
+                                                                </div>
+                                                                <div class="mb-3">
+                                                                        <label class="form-label" for="comment">Comment</label>
+                                                                        <textarea class="form-control" id="comment" name="comment" rows="3"></textarea>
+                                                                </div>
+                                                        </div>
+                                                </div>
 						<div class="modal-footer">
 							<button class="btn btn-primary" type="submit">Submit</button>
 							<button type="button" class="btn btn-secondary"
@@ -133,7 +144,7 @@
             const stars = document.querySelectorAll('#feedbackModal .star');
             const input = document.getElementById('rating');
 
-            function setRating(val) {
+            window.setFeedbackRating = function(val) {
                 input.value = val;
                 stars.forEach(s => {
                     if (parseInt(s.getAttribute('data-value')) <= val) {
@@ -146,9 +157,38 @@
                 });
             }
 
+            window.populateFeedbackModal = function(data) {
+                document.getElementById('feedbackOtherName').textContent = data.otherUserName;
+                document.getElementById('feedbackProjectTitle').textContent = data.projectTitle;
+
+                const otherDiv = document.getElementById('otherFeedback');
+                if (data.otherRating !== null || data.otherComment) {
+                    otherDiv.classList.remove('d-none');
+                    document.getElementById('otherFeedbackName').textContent = data.otherUserName;
+                    document.getElementById('otherRating').textContent = data.otherRating ?? '';
+                    document.getElementById('otherComment').textContent = data.otherComment ?? '';
+                } else {
+                    otherDiv.classList.add('d-none');
+                }
+
+                const form = document.getElementById('myFeedbackForm');
+                const display = document.getElementById('myFeedbackDisplay');
+                if (data.myRating !== null || data.myComment) {
+                    form.classList.add('d-none');
+                    display.classList.remove('d-none');
+                    document.getElementById('myRating').textContent = data.myRating ?? '';
+                    document.getElementById('myComment').textContent = data.myComment ?? '';
+                } else {
+                    form.classList.remove('d-none');
+                    display.classList.add('d-none');
+                    setFeedbackRating(0);
+                    document.getElementById('comment').value = '';
+                }
+            }
+
             stars.forEach(star => {
                 star.addEventListener('click', () => {
-                    setRating(parseInt(star.getAttribute('data-value')));
+                    setFeedbackRating(parseInt(star.getAttribute('data-value')));
                 });
             });
         });


### PR DESCRIPTION
## Summary
- record who sends feedback and who receives it
- expose feedback data through new fields in `MatchInfoDTO`
- show existing feedback and hide form when already submitted
- allow dashboards to fill modal with both comments

## Testing
- `./mvnw -q test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6879da346a0883209fe2530198cc6308