### PR TITLE
Add edit profile link for advisors

### DIFF
--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -5,6 +5,7 @@
 
 	<div class="container mt-4">
 		<h2 th:text="'Welcome, ' + ${advisor.fullName}">Advisor Name</h2>
+                <a th:href="@{/profile/{id}/edit(id=${advisor.id})}" class="btn btn-primary mt-3">Edit Profile</a>
 
 		<div class="row text-center my-4">
 			<div class="col-md-4 mb-3">


### PR DESCRIPTION
## Summary
- add a profile edit button to the advisor dashboard

## Testing
- `mvnw -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6879dec3ac8c8320a11d1a6cc14c700e