### PR TITLE
Fix NonUniqueResultException when fetching project info

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/MatchInfoController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/MatchInfoController.java
@@ -43,6 +43,8 @@ public class MatchInfoController {
         User other = current.getId().equals(match.getStudent().getId()) ? match.getAdvisor() : match.getStudent();
         Project project = projectRepo
                 .findByStudentAndAdvisorAndStatus(match.getStudent(), match.getAdvisor(), ProjectStatus.COMPLETED)
+                .stream()
+                .findFirst()
                 .orElse(null);
         String title = project != null ? project.getTitle() : "";
         var myFb = feedbackRepo.findByMatchAndFromUser(match, current).orElse(null);

--- a/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
@@ -69,9 +69,9 @@ public class ProjectController {
                 boolean hasMatch = matchRepository.existsByStudentIdAndAdvisorIdAndStatus(
                                 project.getStudent().getId(), advisor.getId(), MatchStatus.ACCEPTED);
 
-                boolean hasActive = projectRepository
+                boolean hasActive = !projectRepository
                                 .findByStudentAndAdvisorAndStatusAndDeletedFalse(project.getStudent(), advisor, ProjectStatus.IN_PROGRESS)
-                                .isPresent();
+                                .isEmpty();
 
                 if (project.getAdvisor() == null && hasMatch && !hasActive) {
                         project.setAdvisor(advisor);
@@ -108,7 +108,9 @@ public class ProjectController {
                 matchRepository.save(match);
 
                 var optProject = projectRepository.findByStudentAndAdvisorAndStatusAndDeletedFalse(
-                                match.getStudent(), match.getAdvisor(), ProjectStatus.IN_PROGRESS);
+                                match.getStudent(), match.getAdvisor(), ProjectStatus.IN_PROGRESS)
+                                .stream()
+                                .findFirst();
 
                 optProject.ifPresent(p -> {
                         p.setStatus(ProjectStatus.COMPLETED);

--- a/src/main/java/com/uanl/asesormatch/repository/ProjectRepository.java
+++ b/src/main/java/com/uanl/asesormatch/repository/ProjectRepository.java
@@ -17,9 +17,9 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
 
     long countByAdvisorAndStatus(User advisor, ProjectStatus status);
 
-    java.util.Optional<Project> findByStudentAndAdvisorAndStatus(User student, User advisor, ProjectStatus status);
+    java.util.List<Project> findByStudentAndAdvisorAndStatus(User student, User advisor, ProjectStatus status);
 
-    java.util.Optional<Project> findByStudentAndAdvisorAndStatusAndDeletedFalse(User student, User advisor, ProjectStatus status);
+    java.util.List<Project> findByStudentAndAdvisorAndStatusAndDeletedFalse(User student, User advisor, ProjectStatus status);
 
     java.util.List<Project> findByAdvisorAndStatus(User advisor, ProjectStatus status);
 


### PR DESCRIPTION
## Summary
- avoid incorrect Optional queries in `ProjectRepository`
- adapt match and project controllers to new list-based queries

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879e0041f10832089f9a930f6a8a0f0