### PR TITLE
Fix counterpart name in feedback modal

### DIFF
--- a/src/main/resources/templates/fragments/advisorFragments.html
+++ b/src/main/resources/templates/fragments/advisorFragments.html
@@ -90,7 +90,7 @@
 			<div class="modal-dialog">
 				<div class="modal-content">
 					<form th:action="@{/feedback/submit}" method="post">
-						<input type="hidden" name="matchId" id="feedbackMatchId" />
+                                                <input type="hidden" name="matchId" id="feedbackMatchId" th:value="${feedbackMatchId}" />
 						<div class="modal-header">
 							<h5 class="modal-title">Feedback</h5>
 							<button type="button" class="btn-close" data-bs-dismiss="modal"></button>
@@ -99,8 +99,8 @@
                                                         <p class="small text-muted mb-3">
                                                                 Estos comentarios nos ayudaran a mejorar nuestro sistema de emparejamiento.
                                                                 ¿cómo te sentiste de trabajar con
-                                                                <strong id="feedbackOtherName"></strong>
-                                                                en el proyecto <strong id="feedbackProjectTitle"></strong>?
+                                                                <strong id="feedbackOtherName" th:text="${feedbackOtherName}"></strong>
+                                                                en el proyecto <strong id="feedbackProjectTitle" th:text="${feedbackProjectTitle}"></strong>?
                                                         </p>
                                                         <div id="otherFeedback" class="border rounded p-2 mb-3 d-none">
                                                                 <h6 class="fw-bold mb-1" id="otherFeedbackName"></h6>


### PR DESCRIPTION
## Summary
- render counterpart name from server when opening feedback modal
- support feedbackMatchId in student dashboard controller
- support feedbackMatchId in advisor dashboard controller
- show names in modal via thymeleaf bindings

## Testing
- `./mvnw -q test` *(fails: repository download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6879e35d2734832097f61d744a25e2fd