### PR TITLE
Implement JWT auth for recommendations API

### DIFF
--- a/src/main/java/com/uanl/asesormatch/client/MatchingEngineClient.java
+++ b/src/main/java/com/uanl/asesormatch/client/MatchingEngineClient.java
@@ -12,24 +12,43 @@ import org.springframework.web.client.RestTemplate;
 import com.uanl.asesormatch.dto.MatchRequestDTO;
 import com.uanl.asesormatch.dto.RecommendationDTO;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Component
 public class MatchingEngineClient {
 
-	public List<RecommendationDTO> getRecommendations(Long studentId) {
-		RestTemplate restTemplate = new RestTemplate();
-		String url = "http://localhost:8000/match/calculate";
+    public List<RecommendationDTO> getRecommendations(Long studentId) {
+        RestTemplate restTemplate = new RestTemplate();
+        String baseUrl = "http://localhost:8000";
 
-		MatchRequestDTO requestDTO = new MatchRequestDTO(studentId);
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(MediaType.APPLICATION_JSON);
-		HttpEntity<MatchRequestDTO> request = new HttpEntity<>(requestDTO, headers);
+        // Login to obtain JWT token
+        String loginUrl = baseUrl + "/login";
+        Map<String, Long> loginBody = new HashMap<>();
+        loginBody.put("userId", studentId);
+        HttpHeaders loginHeaders = new HttpHeaders();
+        loginHeaders.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<Map<String, Long>> loginRequest = new HttpEntity<>(loginBody, loginHeaders);
+        ResponseEntity<Map> loginResponse = restTemplate.postForEntity(loginUrl, loginRequest, Map.class);
+        String token = loginResponse.getBody() != null ? (String) loginResponse.getBody().get("token") : null;
 
-		ResponseEntity<List<RecommendationDTO>> response = restTemplate.exchange(url, HttpMethod.POST, request,
-				new ParameterizedTypeReference<List<RecommendationDTO>>() {
-				});
+        String url = baseUrl + "/match/calculate";
+        MatchRequestDTO requestDTO = new MatchRequestDTO(studentId);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (token != null) {
+            headers.setBearerAuth(token);
+        }
+        HttpEntity<MatchRequestDTO> request = new HttpEntity<>(requestDTO, headers);
 
-		return response.getBody();
-	}
+        ResponseEntity<List<RecommendationDTO>> response = restTemplate.exchange(
+            url,
+            HttpMethod.POST,
+            request,
+            new ParameterizedTypeReference<List<RecommendationDTO>>() {}
+        );
+
+        return response.getBody();
+    }
 }


### PR DESCRIPTION
## Summary
- log in to the recommendations API before calling `/match/calculate`
- store returned token and send as `Authorization` header

## Testing
- `./mvnw -q test` *(failed: could not download Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6879e4fdc564832094b9d0f51554d1a6