### PR TITLE
Fix raw type warning and make MatchingEngine configurable

### DIFF
--- a/src/main/java/com/uanl/asesormatch/client/MatchingEngineClient.java
+++ b/src/main/java/com/uanl/asesormatch/client/MatchingEngineClient.java
@@ -1,5 +1,6 @@
 package com.uanl.asesormatch.client;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -19,9 +20,14 @@ import java.util.Map;
 @Component
 public class MatchingEngineClient {
 
+    private final String baseUrl;
+
+    public MatchingEngineClient(@Value("${matching.engine.base-url:http://localhost:8000}") String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
     public List<RecommendationDTO> getRecommendations(Long studentId) {
         RestTemplate restTemplate = new RestTemplate();
-        String baseUrl = "http://localhost:8000";
 
         // Login to obtain JWT token
         String loginUrl = baseUrl + "/login";
@@ -30,7 +36,12 @@ public class MatchingEngineClient {
         HttpHeaders loginHeaders = new HttpHeaders();
         loginHeaders.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<Map<String, Long>> loginRequest = new HttpEntity<>(loginBody, loginHeaders);
-        ResponseEntity<Map> loginResponse = restTemplate.postForEntity(loginUrl, loginRequest, Map.class);
+        ResponseEntity<Map<String, Object>> loginResponse = restTemplate.exchange(
+            loginUrl,
+            HttpMethod.POST,
+            loginRequest,
+            new ParameterizedTypeReference<Map<String, Object>>() {}
+        );
         String token = loginResponse.getBody() != null ? (String) loginResponse.getBody().get("token") : null;
 
         String url = baseUrl + "/match/calculate";

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,6 @@ spring.security.oauth2.client.provider.azure.issuer-uri=https://login.microsofto
 
 # Default advisor email override
 advisor.override-email=nicolas.ortiz@uni.edu
+
+# Base URL for the matching engine service
+matching.engine.base-url=http://localhost:8000


### PR DESCRIPTION
## Summary
- parameterize login request map in `MatchingEngineClient`
- switch to `exchange` to avoid raw type warning
- inject matching engine base URL via property
- add `matching.engine.base-url` property

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879ec6cec948320b5d0cc8348494404