### PR TITLE
Fix feedback modal name by validating match role

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/MatchInfoController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/MatchInfoController.java
@@ -40,7 +40,16 @@ public class MatchInfoController {
         if (match == null) {
             return ResponseEntity.notFound().build();
         }
-        User other = current.getId().equals(match.getStudent().getId()) ? match.getAdvisor() : match.getStudent();
+
+        // validate that the authenticated user belongs to the match
+        if (current.getRole() == Role.ADVISOR && !match.getAdvisor().getId().equals(current.getId())) {
+            return ResponseEntity.status(403).build();
+        }
+        if (current.getRole() == Role.STUDENT && !match.getStudent().getId().equals(current.getId())) {
+            return ResponseEntity.status(403).build();
+        }
+
+        User other = current.getRole() == Role.ADVISOR ? match.getStudent() : match.getAdvisor();
         Project project = projectRepo
                 .findByStudentAndAdvisorAndStatus(match.getStudent(), match.getAdvisor(), ProjectStatus.COMPLETED)
                 .stream()


### PR DESCRIPTION
## Summary
- verify the authenticated user's role when fetching a match for feedback
- select the counterpart name based on the role

## Testing
- `./mvnw -q test` *(fails: Could not download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6879f22f648483209d3b706cf2abef6c