### PR TITLE
Allow mutual feedback notifications

### DIFF
--- a/src/main/java/com/uanl/asesormatch/service/FeedbackService.java
+++ b/src/main/java/com/uanl/asesormatch/service/FeedbackService.java
@@ -1,0 +1,70 @@
+package com.uanl.asesormatch.service;
+
+import com.uanl.asesormatch.entity.Feedback;
+import com.uanl.asesormatch.entity.Project;
+import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.enums.Role;
+import com.uanl.asesormatch.repository.FeedbackRepository;
+import com.uanl.asesormatch.repository.NotificationRepository;
+import com.uanl.asesormatch.repository.ProjectRepository;
+import com.uanl.asesormatch.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class FeedbackService {
+    private final ProjectRepository projectRepo;
+    private final FeedbackRepository feedbackRepo;
+    private final UserRepository userRepo;
+    private final NotificationRepository notificationRepo;
+    private final NotificationService notificationService;
+
+    public FeedbackService(ProjectRepository projectRepo,
+                           FeedbackRepository feedbackRepo,
+                           UserRepository userRepo,
+                           NotificationRepository notificationRepo,
+                           NotificationService notificationService) {
+        this.projectRepo = projectRepo;
+        this.feedbackRepo = feedbackRepo;
+        this.userRepo = userRepo;
+        this.notificationRepo = notificationRepo;
+        this.notificationService = notificationService;
+    }
+
+    public void submitFeedback(User user, Long projectId, Integer rating, String comment) {
+        Project project = projectRepo.findById(projectId).orElseThrow();
+
+        if (!feedbackRepo.existsByProjectAndFromUser(project, user)) {
+            User other = user.getId().equals(project.getStudent().getId())
+                    ? project.getAdvisor()
+                    : project.getStudent();
+            Feedback fb = new Feedback();
+            fb.setProject(project);
+            fb.setFromUser(user);
+            fb.setToUser(other);
+            fb.setCreatedAt(LocalDateTime.now());
+            fb.setRating(rating);
+            fb.setComment(comment);
+            feedbackRepo.save(fb);
+        }
+
+        String projectIdToken = "feedbackProjectId=" + projectId;
+        var notifications = notificationRepo.findByUserAndMessageContaining(user, projectIdToken);
+        if (!notifications.isEmpty()) {
+            notificationRepo.deleteAll(notifications);
+        }
+
+        User otherUser = user.getId().equals(project.getStudent().getId())
+                ? project.getAdvisor()
+                : project.getStudent();
+        if (otherUser != null && !feedbackRepo.existsByProjectAndFromUser(project, otherUser)) {
+            String url = otherUser.getRole() == Role.ADVISOR
+                    ? "/advisor-dashboard?feedbackProjectId=" + projectId
+                    : "/dashboard?feedbackProjectId=" + projectId;
+            String msg = "El otro participante ya env\u00EDo su feedback para el proyecto '"
+                    + project.getTitle() + "'. Por favor da el tuyo <a href='" + url + "'>aqu\u00ED</a>";
+            notificationService.notify(otherUser, msg);
+        }
+    }
+}

--- a/src/test/java/com/uanl/asesormatch/service/FeedbackServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/FeedbackServiceTests.java
@@ -1,0 +1,80 @@
+package com.uanl.asesormatch.service;
+
+import com.uanl.asesormatch.entity.Project;
+import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.enums.ProjectStatus;
+import com.uanl.asesormatch.enums.Role;
+import com.uanl.asesormatch.repository.FeedbackRepository;
+import com.uanl.asesormatch.repository.NotificationRepository;
+import com.uanl.asesormatch.repository.ProjectRepository;
+import com.uanl.asesormatch.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class FeedbackServiceTests {
+    @Autowired
+    private ProjectRepository projectRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private FeedbackRepository feedbackRepository;
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    private FeedbackService feedbackService;
+
+    private User student;
+    private User advisor;
+    private Project project;
+
+    @BeforeEach
+    void setUp() {
+        NotificationService notificationService = new NotificationService(notificationRepository);
+        feedbackService = new FeedbackService(projectRepository, feedbackRepository,
+                userRepository, notificationRepository, notificationService);
+
+        student = new User();
+        student.setFullName("Student");
+        student.setEmail("s@test.com");
+        student.setRole(Role.STUDENT);
+        userRepository.save(student);
+
+        advisor = new User();
+        advisor.setFullName("Advisor");
+        advisor.setEmail("a@test.com");
+        advisor.setRole(Role.ADVISOR);
+        userRepository.save(advisor);
+
+        project = new Project();
+        project.setTitle("P1");
+        project.setDescription("D1");
+        project.setStudent(student);
+        project.setAdvisor(advisor);
+        project.setStatus(ProjectStatus.COMPLETED);
+        projectRepository.save(project);
+    }
+
+    @Test
+    void otherUserGetsNotificationIfNoFeedback() {
+        feedbackService.submitFeedback(student, project.getId(), 5, "Great");
+
+        assertTrue(feedbackRepository.existsByProjectAndFromUser(project, student));
+        var notes = notificationRepository.findByUserOrderByCreatedAtDesc(advisor);
+        assertEquals(1, notes.size());
+    }
+
+    @Test
+    void notificationRemovedWhenOtherGivesFeedback() {
+        feedbackService.submitFeedback(student, project.getId(), 5, "Great");
+        feedbackService.submitFeedback(advisor, project.getId(), 4, "Ok");
+
+        assertTrue(feedbackRepository.existsByProjectAndFromUser(project, advisor));
+        var notes = notificationRepository.findByUserOrderByCreatedAtDesc(advisor);
+        assertTrue(notes.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add FeedbackService to encapsulate logic for submitting feedback
- send notification to the other participant if they haven't rated yet
- refactor FeedbackController to use FeedbackService
- test symmetric feedback notifications

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6879f988a28c8320adf10a0ad5e3399e