### PR TITLE
Implement incognito email override

### DIFF
--- a/src/main/java/com/uanl/asesormatch/config/AdvisorEmailProvider.java
+++ b/src/main/java/com/uanl/asesormatch/config/AdvisorEmailProvider.java
@@ -1,20 +1,27 @@
 package com.uanl.asesormatch.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import jakarta.servlet.http.HttpSession;
 
 @Component
 public class AdvisorEmailProvider {
-    private final String advisorEmail;
-
-    public AdvisorEmailProvider(@Value("${advisor.override-email:}") String advisorEmail) {
-        this.advisorEmail = advisorEmail;
+    public AdvisorEmailProvider() {
     }
 
     public String resolveEmail(OidcUser oidcUser) {
-        if (advisorEmail != null && !advisorEmail.isBlank()) {
-            return advisorEmail;
+        ServletRequestAttributes attrs =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attrs != null) {
+            HttpSession session = attrs.getRequest().getSession(false);
+            if (session != null) {
+                String override = (String) session.getAttribute("overrideEmail");
+                if (override != null) {
+                    return override;
+                }
+            }
         }
         return oidcUser.getEmail();
     }

--- a/src/main/java/com/uanl/asesormatch/config/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/uanl/asesormatch/config/CustomOAuth2SuccessHandler.java
@@ -4,35 +4,55 @@ import com.uanl.asesormatch.enums.Role;
 import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.repository.UserRepository;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Component
+
 public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
-	private final UserRepository userRepository;
+    private final UserRepository userRepository;
+    private final String advisorOverrideEmail;
 
-	public CustomOAuth2SuccessHandler(UserRepository userRepository) {
-		this.userRepository = userRepository;
-	}
+    public CustomOAuth2SuccessHandler(UserRepository userRepository,
+                                      @Value("${advisor.override-email:}") String advisorOverrideEmail) {
+        this.userRepository = userRepository;
+        this.advisorOverrideEmail = advisorOverrideEmail;
+    }
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 			Authentication authentication) throws IOException, ServletException {
 
-		OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
-
-		String email = oidcUser.getEmail();
-		String name = oidcUser.getFullName();
-		String universityId = oidcUser.getPreferredUsername();
+        OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
+        String email = oidcUser.getEmail();
+        boolean incognito = false;
+        if (request.getCookies() != null) {
+            for (Cookie c : request.getCookies()) {
+                if ("incognito".equals(c.getName()) && "true".equals(c.getValue())) {
+                    incognito = true;
+                    break;
+                }
+            }
+        }
+        if (incognito && advisorOverrideEmail != null && !advisorOverrideEmail.isBlank()) {
+            request.getSession().setAttribute("overrideEmail", advisorOverrideEmail);
+            email = advisorOverrideEmail;
+        } else {
+            request.getSession().removeAttribute("overrideEmail");
+        }
+        String name = oidcUser.getFullName();
+        String universityId = oidcUser.getPreferredUsername();
 
 		Optional<User> existingUser = userRepository.findByEmail(email);
 

--- a/src/main/resources/static/js/incognito.js
+++ b/src/main/resources/static/js/incognito.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', function() {
+    if (!navigator.storage || !navigator.storage.estimate) {
+        return;
+    }
+    navigator.storage.estimate().then(function(estimate) {
+        var quota = estimate && estimate.quota ? estimate.quota : 0;
+        var incognito = quota && quota < 120000000;
+        if (incognito) {
+            document.cookie = 'incognito=true; path=/';
+        } else {
+            document.cookie = 'incognito=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+        }
+    });
+});

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -2,12 +2,13 @@
 <html xmlns:th="http://www.thymeleaf.org"
 	th:replace="~{layout :: layout(~{::body}, 'Login')}">
 <body>
-	<div class="container mt-5 text-center">
-		<h1 class="mb-4">Academic Matching Platform</h1>
-		<p class="lead">Log in with your university account to continue</p>
+    <div class="container mt-5 text-center">
+        <h1 class="mb-4">Academic Matching Platform</h1>
+        <p class="lead">Log in with your university account to continue</p>
 
-		<a href="/oauth2/authorization/azure"
-			class="btn btn-primary btn-lg mt-3"> Sign in with Microsoft </a>
-	</div>
+        <a href="/oauth2/authorization/azure"
+                class="btn btn-primary btn-lg mt-3"> Sign in with Microsoft </a>
+    </div>
+    <script th:src="@{/js/incognito.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add incognito detection script on login page
- use override email only when incognito
- move advisor email override from provider to session during login
- fix imports for CustomOAuth2SuccessHandler

## Testing
- `./mvnw test -q` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_687d2fbf345083209f8f97ca14d2a2e9