### PR TITLE
Use query param to simulate advisor login

### DIFF
--- a/src/main/java/com/uanl/asesormatch/config/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/uanl/asesormatch/config/CustomOAuth2SuccessHandler.java
@@ -4,14 +4,13 @@ import com.uanl.asesormatch.enums.Role;
 import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.repository.UserRepository;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -22,12 +21,9 @@ import java.util.Optional;
 public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final UserRepository userRepository;
-    private final String advisorOverrideEmail;
 
-    public CustomOAuth2SuccessHandler(UserRepository userRepository,
-                                      @Value("${advisor.override-email:}") String advisorOverrideEmail) {
+    public CustomOAuth2SuccessHandler(UserRepository userRepository) {
         this.userRepository = userRepository;
-        this.advisorOverrideEmail = advisorOverrideEmail;
     }
 
 	@Override
@@ -36,20 +32,14 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
 
         OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
         String email = oidcUser.getEmail();
-        boolean incognito = false;
-        if (request.getCookies() != null) {
-            for (Cookie c : request.getCookies()) {
-                if ("incognito".equals(c.getName()) && "true".equals(c.getValue())) {
-                    incognito = true;
-                    break;
-                }
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            String override = (String) session.getAttribute("overrideEmail");
+            if (override != null && !override.isBlank()) {
+                email = override;
+            } else {
+                session.removeAttribute("overrideEmail");
             }
-        }
-        if (incognito && advisorOverrideEmail != null && !advisorOverrideEmail.isBlank()) {
-            request.getSession().setAttribute("overrideEmail", advisorOverrideEmail);
-            email = advisorOverrideEmail;
-        } else {
-            request.getSession().removeAttribute("overrideEmail");
         }
         String name = oidcUser.getFullName();
         String universityId = oidcUser.getPreferredUsername();

--- a/src/main/java/com/uanl/asesormatch/controller/LoginController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/LoginController.java
@@ -1,13 +1,28 @@
 package com.uanl.asesormatch.controller;
 
+import jakarta.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class LoginController {
 
-	@GetMapping("/login")
-	public String loginPage() {
-		return "login";
-	}
+    private final String advisorOverrideEmail;
+
+    public LoginController(@Value("${advisor.override-email:}") String advisorOverrideEmail) {
+        this.advisorOverrideEmail = advisorOverrideEmail;
+    }
+
+    @GetMapping("/login")
+    public String loginPage(@RequestParam(value = "as", required = false) String as,
+                            HttpSession session) {
+        if ("advisor".equalsIgnoreCase(as) && advisorOverrideEmail != null && !advisorOverrideEmail.isBlank()) {
+            session.setAttribute("overrideEmail", advisorOverrideEmail);
+        } else {
+            session.removeAttribute("overrideEmail");
+        }
+        return "login";
+    }
 }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -9,6 +9,5 @@
         <a href="/oauth2/authorization/azure"
                 class="btn btn-primary btn-lg mt-3"> Sign in with Microsoft </a>
     </div>
-    <script th:src="@{/js/incognito.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- override login email using `as=advisor` query parameter
- load advisor email in the login success handler from the session
- remove old incognito JavaScript from login page

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687d379d12808320aedbb50d2c4997ed