### PR TITLE
Replace direct oidc email calls with provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# AsesorMatchApp
+
+This project uses Spring Security with OIDC. When obtaining the authenticated user's email, always use `AdvisorEmailProvider.resolveEmail(OidcUser)` instead of calling `OidcUser#getEmail()` directly. This ensures that any session override logic is respected.

--- a/src/main/java/com/uanl/asesormatch/config/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/uanl/asesormatch/config/CustomOAuth2SuccessHandler.java
@@ -3,6 +3,7 @@ package com.uanl.asesormatch.config;
 import com.uanl.asesormatch.enums.Role;
 import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.repository.UserRepository;
+import com.uanl.asesormatch.config.AdvisorEmailProvider;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,9 +22,11 @@ import java.util.Optional;
 public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final UserRepository userRepository;
+    private final AdvisorEmailProvider emailProvider;
 
-    public CustomOAuth2SuccessHandler(UserRepository userRepository) {
+    public CustomOAuth2SuccessHandler(UserRepository userRepository, AdvisorEmailProvider emailProvider) {
         this.userRepository = userRepository;
+        this.emailProvider = emailProvider;
     }
 
 	@Override
@@ -31,16 +34,7 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
 			Authentication authentication) throws IOException, ServletException {
 
         OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
-        String email = oidcUser.getEmail();
-        HttpSession session = request.getSession(false);
-        if (session != null) {
-            String override = (String) session.getAttribute("overrideEmail");
-            if (override != null && !override.isBlank()) {
-                email = override;
-            } else {
-                session.removeAttribute("overrideEmail");
-            }
-        }
+        String email = emailProvider.resolveEmail(oidcUser);
         String name = oidcUser.getFullName();
         String universityId = oidcUser.getPreferredUsername();
 

--- a/src/main/java/com/uanl/asesormatch/controller/FeedbackController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/FeedbackController.java
@@ -4,6 +4,7 @@ import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.enums.Role;
 import com.uanl.asesormatch.service.FeedbackService;
 import com.uanl.asesormatch.repository.UserRepository;
+import com.uanl.asesormatch.config.AdvisorEmailProvider;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Controller;
@@ -16,10 +17,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class FeedbackController {
     private final FeedbackService feedbackService;
     private final UserRepository userRepo;
+    private final AdvisorEmailProvider emailProvider;
 
-    public FeedbackController(FeedbackService feedbackService, UserRepository userRepo) {
+    public FeedbackController(FeedbackService feedbackService, UserRepository userRepo,
+                              AdvisorEmailProvider emailProvider) {
         this.feedbackService = feedbackService;
         this.userRepo = userRepo;
+        this.emailProvider = emailProvider;
     }
 
     @PostMapping("/submit")
@@ -27,7 +31,7 @@ public class FeedbackController {
                                  @RequestParam Long projectId,
                                  @RequestParam Integer rating,
                                  @RequestParam String comment) {
-        User user = userRepo.findByEmail(oidcUser.getEmail()).orElseThrow();
+        User user = userRepo.findByEmail(emailProvider.resolveEmail(oidcUser)).orElseThrow();
         feedbackService.submitFeedback(user, projectId, rating, comment);
 
         String redirect = user.getRole() == Role.ADVISOR ? "/advisor-dashboard" : "/dashboard";

--- a/src/main/java/com/uanl/asesormatch/controller/MatchController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/MatchController.java
@@ -16,25 +16,29 @@ import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.service.MatchingService;
 import com.uanl.asesormatch.service.UserService;
 import com.uanl.asesormatch.enums.MatchStatus;
+import com.uanl.asesormatch.config.AdvisorEmailProvider;
 
 @RestController
 @RequestMapping("/match")
 public class MatchController {
 
-	private final MatchingService matchingService;
-	private final UserService userService;
+        private final MatchingService matchingService;
+        private final UserService userService;
+        private final AdvisorEmailProvider emailProvider;
 
-	public MatchController(MatchingService matchingService, UserService userService) {
-		this.matchingService = matchingService;
-		this.userService = userService;
-	}
+        public MatchController(MatchingService matchingService, UserService userService,
+                               AdvisorEmailProvider emailProvider) {
+                this.matchingService = matchingService;
+                this.userService = userService;
+                this.emailProvider = emailProvider;
+        }
 
         @PostMapping("/request")
         public ResponseEntity<Void> requestMatch(@AuthenticationPrincipal OidcUser principal,
                         @RequestParam Long advisorId, @RequestParam Double score) {
 
-		User student = userService.findByEmail(principal.getEmail())
-				.orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+                User student = userService.findByEmail(emailProvider.resolveEmail(principal))
+                                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
 
 		matchingService.requestMatch(student.getId(), advisorId, score);
 

--- a/src/main/java/com/uanl/asesormatch/controller/NotificationController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/NotificationController.java
@@ -4,6 +4,7 @@ import com.uanl.asesormatch.entity.Notification;
 import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.repository.NotificationRepository;
 import com.uanl.asesormatch.repository.UserRepository;
+import com.uanl.asesormatch.config.AdvisorEmailProvider;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Controller;
@@ -16,17 +17,20 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class NotificationController {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
+    private final AdvisorEmailProvider emailProvider;
 
     public NotificationController(NotificationRepository notificationRepository,
-                                  UserRepository userRepository) {
+                                  UserRepository userRepository,
+                                  AdvisorEmailProvider emailProvider) {
         this.notificationRepository = notificationRepository;
         this.userRepository = userRepository;
+        this.emailProvider = emailProvider;
     }
 
     @PostMapping("/delete")
     public String deleteNotification(@AuthenticationPrincipal OidcUser oidcUser,
                                      @RequestParam Long id) {
-        User user = userRepository.findByEmail(oidcUser.getEmail()).orElseThrow();
+        User user = userRepository.findByEmail(emailProvider.resolveEmail(oidcUser)).orElseThrow();
         Notification n = notificationRepository.findById(id).orElse(null);
         if (n != null && n.getUser().getId().equals(user.getId())) {
             notificationRepository.delete(n);

--- a/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
@@ -47,7 +47,7 @@ public class ProjectController {
 	@PostMapping("/new")
 	public String submitProject(@AuthenticationPrincipal OidcUser oidcUser, @ModelAttribute("project") ProjectDTO dto) {
 
-		User student = userRepository.findByEmail(oidcUser.getEmail()).orElseThrow();
+                User student = userRepository.findByEmail(emailProvider.resolveEmail(oidcUser)).orElseThrow();
 
 		Project project = new Project();
 		project.setTitle(dto.getTitle());
@@ -159,7 +159,7 @@ public class ProjectController {
         @PostMapping("/delete")
         public String deleteProject(@AuthenticationPrincipal OidcUser oidcUser,
                                     @RequestParam Long projectId) {
-                User student = userRepository.findByEmail(oidcUser.getEmail()).orElseThrow();
+                User student = userRepository.findByEmail(emailProvider.resolveEmail(oidcUser)).orElseThrow();
                 Project project = projectRepository.findById(projectId).orElseThrow();
 
                 if (!project.getStudent().getId().equals(student.getId())) {

--- a/src/main/java/com/uanl/asesormatch/controller/ProjectFeedbackInfoController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/ProjectFeedbackInfoController.java
@@ -6,6 +6,7 @@ import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.repository.ProjectRepository;
 import com.uanl.asesormatch.repository.UserRepository;
 import com.uanl.asesormatch.repository.FeedbackRepository;
+import com.uanl.asesormatch.config.AdvisorEmailProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -20,18 +21,20 @@ public class ProjectFeedbackInfoController {
     private final ProjectRepository projectRepo;
     private final UserRepository userRepo;
     private final FeedbackRepository feedbackRepo;
+    private final AdvisorEmailProvider emailProvider;
 
     public ProjectFeedbackInfoController(ProjectRepository projectRepo, UserRepository userRepo,
-                                         FeedbackRepository feedbackRepo) {
+                                         FeedbackRepository feedbackRepo, AdvisorEmailProvider emailProvider) {
         this.projectRepo = projectRepo;
         this.userRepo = userRepo;
         this.feedbackRepo = feedbackRepo;
+        this.emailProvider = emailProvider;
     }
 
     @GetMapping("/{id}/feedback")
     public ResponseEntity<ProjectFeedbackInfoDTO> info(@AuthenticationPrincipal OidcUser oidcUser,
                                                        @PathVariable Long id) {
-        User current = userRepo.findByEmail(oidcUser.getEmail()).orElseThrow();
+        User current = userRepo.findByEmail(emailProvider.resolveEmail(oidcUser)).orElseThrow();
         Project project = projectRepo.findById(id).orElse(null);
         if (project == null) {
             return ResponseEntity.notFound().build();

--- a/src/main/java/com/uanl/asesormatch/controller/student/StudentProfileController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/student/StudentProfileController.java
@@ -18,6 +18,7 @@ import com.uanl.asesormatch.entity.Profile;
 import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.repository.ProfileRepository;
 import com.uanl.asesormatch.repository.UserRepository;
+import com.uanl.asesormatch.config.AdvisorEmailProvider;
 
 import jakarta.validation.Valid;
 
@@ -25,13 +26,16 @@ import jakarta.validation.Valid;
 @RequestMapping("/profile")
 public class StudentProfileController {
 
-	private final UserRepository userRepository;
-	private final ProfileRepository profileRepository;
+        private final UserRepository userRepository;
+        private final ProfileRepository profileRepository;
+        private final AdvisorEmailProvider emailProvider;
 
-	public StudentProfileController(UserRepository userRepository, ProfileRepository profileRepository) {
-		this.userRepository = userRepository;
-		this.profileRepository = profileRepository;
-	}
+        public StudentProfileController(UserRepository userRepository, ProfileRepository profileRepository,
+                                        AdvisorEmailProvider emailProvider) {
+                this.userRepository = userRepository;
+                this.profileRepository = profileRepository;
+                this.emailProvider = emailProvider;
+        }
 
 	@GetMapping("/{id}/edit")
 	public String editProfileForm(@PathVariable Long id, Model model) {
@@ -61,7 +65,7 @@ public class StudentProfileController {
 			return "edit-profile";
 		}
 
-		User user = userRepository.findByEmail(oidcUser.getEmail()).orElseThrow();
+                User user = userRepository.findByEmail(emailProvider.resolveEmail(oidcUser)).orElseThrow();
 		Profile profile = user.getProfile() == null ? new Profile() : user.getProfile();
 
 		profile.setAreas(dto.getAreas());


### PR DESCRIPTION
## Summary
- use `AdvisorEmailProvider.resolveEmail` everywhere an `OidcUser` email is required
- inject `AdvisorEmailProvider` into controllers and success handler
- document email retrieval

## Testing
- `mvnw -q test` *(fails: repo.maven.apache.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687d3eec5a34832096a54b506b02dbcb