### PR TITLE
Implement modal warning for projects with pending stories

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/ProjectApiController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/ProjectApiController.java
@@ -1,0 +1,48 @@
+package com.uanl.asesormatch.controller;
+
+import com.uanl.asesormatch.entity.Project;
+import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.service.StoryService;
+import com.uanl.asesormatch.repository.ProjectRepository;
+import com.uanl.asesormatch.repository.UserRepository;
+import com.uanl.asesormatch.config.AdvisorEmailProvider;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/projects")
+public class ProjectApiController {
+    private final ProjectRepository projectRepository;
+    private final UserRepository userRepository;
+    private final StoryService storyService;
+    private final AdvisorEmailProvider emailProvider;
+
+    public ProjectApiController(ProjectRepository projectRepository, UserRepository userRepository,
+                                StoryService storyService, AdvisorEmailProvider emailProvider) {
+        this.projectRepository = projectRepository;
+        this.userRepository = userRepository;
+        this.storyService = storyService;
+        this.emailProvider = emailProvider;
+    }
+
+    @GetMapping("/{id}/pending-stories")
+    public ResponseEntity<Boolean> pendingStories(@AuthenticationPrincipal OidcUser oidcUser,
+                                                  @PathVariable Long id) {
+        User current = userRepository.findByEmail(emailProvider.resolveEmail(oidcUser)).orElseThrow();
+        Project project = projectRepository.findById(id).orElse(null);
+        if (project == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (project.getAdvisor() != null && !current.getId().equals(project.getStudent().getId())
+                && !current.getId().equals(project.getAdvisor().getId())) {
+            return ResponseEntity.status(403).build();
+        }
+        boolean pending = storyService.hasPendingStories(project);
+        return ResponseEntity.ok(pending);
+    }
+}

--- a/src/main/java/com/uanl/asesormatch/repository/StoryRepository.java
+++ b/src/main/java/com/uanl/asesormatch/repository/StoryRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface StoryRepository extends JpaRepository<Story, Long> {
     List<Story> findByProjectOrderByCreatedAtAsc(Project project);
+
+    long countByProjectAndStatusNot(Project project, com.uanl.asesormatch.enums.StoryStatus status);
 }

--- a/src/main/java/com/uanl/asesormatch/service/StoryService.java
+++ b/src/main/java/com/uanl/asesormatch/service/StoryService.java
@@ -37,6 +37,10 @@ public class StoryService {
         return storyRepository.findById(id).orElseThrow();
     }
 
+    public boolean hasPendingStories(Project project) {
+        return storyRepository.countByProjectAndStatusNot(project, StoryStatus.DONE) > 0;
+    }
+
     public void advanceStatus(Long storyId, User user) {
         Story story = getStory(storyId);
         if (!user.getId().equals(story.getProject().getStudent().getId())) {

--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -184,9 +184,10 @@
 			</tbody>
 		</table>
 		</th:block>
-		<div th:replace="~{fragments/advisorFragments :: profileModal}"></div>
-		<div th:replace="~{fragments/advisorFragments :: feedbackModal}"></div>
-	</div>
+                <div th:replace="~{fragments/advisorFragments :: profileModal}"></div>
+                <div th:replace="~{fragments/advisorFragments :: feedbackModal}"></div>
+                <div th:replace="~{fragments/advisorFragments :: pendingStoriesModal}"></div>
+        </div>
 	<script>
         document.addEventListener('DOMContentLoaded', function() {
         function buildStudentProfileHTML(user) {
@@ -274,6 +275,31 @@
                     }
                     new bootstrap.Modal('#feedbackModal').show();
                 });
+        }
+
+        document.querySelectorAll('form[action$="/project/complete-project"]').forEach(form => {
+            form.addEventListener('submit', async e => {
+                e.preventDefault();
+                const id = form.querySelector('input[name="projectId"]').value;
+                try {
+                    const res = await fetch(`/api/projects/${id}/pending-stories`, {headers:{'X-Requested-With':'XMLHttpRequest'}});
+                    if (res.ok) {
+                        const pending = await res.json();
+                        if (pending) {
+                            new bootstrap.Modal('#pendingStoriesModal').show();
+                            return;
+                        }
+                    }
+                } catch (err) {}
+                form.submit();
+            });
+        });
+
+        if (params.has('pendingStories')) {
+            new bootstrap.Modal('#pendingStoriesModal').show();
+            params.delete('pendingStories');
+            const q = params.toString();
+            history.replaceState(null, '', window.location.pathname + (q ? '?' + q : ''));
         }
         });
         </script>

--- a/src/main/resources/templates/fragments/advisorFragments.html
+++ b/src/main/resources/templates/fragments/advisorFragments.html
@@ -135,6 +135,26 @@
 				</div>
 			</div>
                 </div>
+
+        <div th:fragment="pendingStoriesModal">
+                <div class="modal fade" id="pendingStoriesModal" tabindex="-1">
+                        <div class="modal-dialog">
+                                <div class="modal-content">
+                                        <div class="modal-header">
+                                                <h5 class="modal-title">Warning</h5>
+                                                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                                        </div>
+                                        <div class="modal-body">
+                                                This project still has stories pending.
+                                        </div>
+                                        <div class="modal-footer">
+                                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </div>
+
         <script>
         document.addEventListener('DOMContentLoaded', function () {
             const stars = document.querySelectorAll('#feedbackModal .star');


### PR DESCRIPTION
## Summary
- block project completion if it still has stories that aren't DONE
- expose an API endpoint to check for pending stories
- show new `pendingStoriesModal` in advisor dashboards
- add JS to verify project completion and open the warning modal when needed

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_687d4698c64083208a46aa4252ec8512