### PR TITLE
Add contextual back buttons

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/student/DashboardController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/student/DashboardController.java
@@ -80,9 +80,10 @@ public class DashboardController {
                return result;
        }
 
-	@GetMapping("/dashboard")
+        @GetMapping("/dashboard")
         public String dashboard(@AuthenticationPrincipal OidcUser oidcUser, Model model,
-                                @RequestParam(required = false) Long feedbackProjectId) {
+                                @RequestParam(required = false) Long feedbackProjectId,
+                                @RequestParam(required = false) String tab) {
                 User user = userRepository.findByEmail(emailProvider.resolveEmail(oidcUser)).orElseThrow();
 
 		if (user.getRole() == Role.ADVISOR) {
@@ -109,7 +110,8 @@ public class DashboardController {
 		model.addAttribute("profile", profile);
 		model.addAttribute("matches", matchHistory);
 		model.addAttribute("studentProjects", studentProjects);
-		model.addAttribute("notifications", notifications);
+                model.addAttribute("notifications", notifications);
+                model.addAttribute("activeTab", tab);
 
 		return "dashboard";
 	}

--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -103,8 +103,8 @@
 				</tr>
 			</thead>
 			<tbody>
-				<tr th:each="p : ${availableProjects}">
-					<td th:text="${p.title}">Title</td>
+                                <tr th:each="p : ${availableProjects}">
+                                        <td><a th:href="@{/project/{id}(id=${p.id})}" th:text="${p.title}">Title</a></td>
 					<td th:text="${p.description}">Description</td>
 					<td th:text="${p.student.fullName}">Student</td>
 					<td th:text="${p.status}">DRAFT</td>
@@ -121,8 +121,8 @@
 						class="text-muted">Blocked</span>
 					</td>
 				</tr>
-				<tr th:each="p : ${projects}">
-					<td th:text="${p.title}">Title</td>
+                                <tr th:each="p : ${projects}">
+                                        <td><a th:href="@{/project/{id}(id=${p.id})}" th:text="${p.title}">Title</a></td>
 					<td th:text="${p.description}">Description</td>
 					<td th:text="${p.student.fullName}">Student</td>
 					<td th:text="${p.status}">IN_PROGRESS</td>
@@ -155,8 +155,8 @@
 				</tr>
 			</thead>
 			<tbody>
-				<tr th:each="p : ${completedProjects}">
-					<td th:text="${p.title}">Project Title</td>
+                                <tr th:each="p : ${completedProjects}">
+                                        <td><a th:href="@{/project/{id}(id=${p.id})}" th:text="${p.title}">Project Title</a></td>
 					<td th:text="${p.student.fullName}">Student</td>
 					<td th:text="${#temporals.format(p.startDate, 'dd/MM/yyyy')}">2025-06-28</td>
 				</tr>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -170,8 +170,8 @@
 							</tr>
 						</thead>
 						<tbody>
-							<tr th:each="p : ${studentProjects}">
-								<td th:text="${p.title}">Title</td>
+                                                        <tr th:each="p : ${studentProjects}">
+                                                                <td><a th:href="@{/project/{id}(id=${p.id})}" th:text="${p.title}">Title</a></td>
 								<td th:text="${p.description}">Description</td>
                                                                 <td th:text="${p.status}">Status</td>
                                                                 <td>
@@ -204,6 +204,13 @@
 	</div>
         <script>
         document.addEventListener('DOMContentLoaded', function() {
+        const initialTab = /*[[${activeTab}]]*/ '';
+        if (initialTab) {
+            const trigger = document.getElementById(initialTab + '-tab');
+            if (trigger) {
+                bootstrap.Tab.getOrCreateInstance(trigger).show();
+            }
+        }
         /* ------------- utils ---------------- */
         function buildProfileHTML(user) {
             const p = user.profile ?? {};

--- a/src/main/resources/templates/fragments/commonFragments.html
+++ b/src/main/resources/templates/fragments/commonFragments.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Common Fragments</title>
+</head>
+<body>
+<div th:fragment="backButton(url, text)">
+    <a th:href="${url}" class="btn btn-link text-decoration-none d-inline-flex align-items-center mb-3">
+        <i class="bi bi-arrow-left me-2"></i> <span th:text="${text}">Back</span>
+    </a>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/project-detail.html
+++ b/src/main/resources/templates/project-detail.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout :: layout(~{::body}, 'Project Detail')}">
+<body>
+<div class="container my-4">
+    <div th:replace="~{fragments/commonFragments :: backButton(${studentView} ? '/dashboard?tab=projects' : '/advisor-dashboard', 'Back to Projects')}"></div>
+    <h3 th:text="${project.title}">Project title</h3>
+    <p th:text="${project.description}">Project description</p>
+    <p><strong>Status:</strong> <span th:text="${project.status}">Status</span></p>
+    <p><strong>Student:</strong> <span th:text="${project.student.fullName}">Student</span></p>
+    <p th:if="${project.advisor != null}"><strong>Advisor:</strong> <span th:text="${project.advisor.fullName}">Advisor</span></p>
+    <a th:href="@{/story/list(projectId=${project.id})}" class="btn btn-outline-secondary mt-3">View Stories</a>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/project-form.html
+++ b/src/main/resources/templates/project-form.html
@@ -2,8 +2,9 @@
 <html xmlns:th="http://www.thymeleaf.org"
 	th:replace="~{layout :: layout(~{::body}, 'Propose New Project')}">
 <body>
-	<div class="container mt-5">
-		<h2>Propose a New Project</h2>
+        <div class="container mt-5">
+                <div th:replace="~{fragments/commonFragments :: backButton(@{/dashboard(tab=${'projects'})}, 'Back to the Projects')}"></div>
+                <h2>Propose a New Project</h2>
 		<form th:action="@{/project/new}" th:object="${project}" method="post"
 			class="mt-3">
 			<div class="mb-3">
@@ -15,9 +16,9 @@
 				<textarea class="form-control" th:field="*{description}" rows="5"
 					required></textarea>
 			</div>
-			<button type="submit" class="btn btn-primary">Submit</button>
-			<a href="/dashboard" class="btn btn-secondary">Cancel</a>
-		</form>
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                        <a th:href="@{/dashboard(tab='projects')}" class="btn btn-secondary">Cancel</a>
+                </form>
 	</div>
 </body>
 </html>

--- a/src/main/resources/templates/project-stories.html
+++ b/src/main/resources/templates/project-stories.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout(~{::body}, 'Project Stories')}">
 <body>
 <div class="container my-4">
+    <div th:replace="~{fragments/commonFragments :: backButton(@{/project/{id}(id=${project.id})}, 'Back to the Project')}"></div>
     <h3 th:text="${project.title}">Project</h3>
     <form th:action="@{/story/add}" method="post" class="mb-3">
         <input type="hidden" name="projectId" th:value="${project.id}" />


### PR DESCRIPTION
## Summary
- create reusable `backButton` fragment with arrow icon
- add new project detail screen
- support `tab` parameter in dashboard to open specific tab
- add project view route and update redirects to maintain context
- insert back buttons and project links in templates

## Testing
- `mvn test` *(fails: Maven could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d4851da9483208100c7368975da16