### PR TITLE
Fix redirect after login to preserve requested dashboard tab

### DIFF
--- a/src/main/java/com/uanl/asesormatch/config/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/uanl/asesormatch/config/CustomOAuth2SuccessHandler.java
@@ -11,6 +11,8 @@ import jakarta.servlet.http.HttpSession;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -55,6 +57,12 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
 			userRepository.save(user);
 		}
 
-		response.sendRedirect("/dashboard");
-	}
+                HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
+                SavedRequest savedRequest = requestCache.getRequest(request, response);
+                String targetUrl = savedRequest != null ? savedRequest.getRedirectUrl() : "/dashboard";
+                if (savedRequest != null) {
+                        requestCache.removeRequest(request, response);
+                }
+                response.sendRedirect(targetUrl);
+        }
 }


### PR DESCRIPTION
## Summary
- update custom OAuth2 success handler to redirect to the originally requested URL if present

## Testing
- `./mvnw -q -DskipTests package` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_687d4d03f41c83209c179f54cffdc0d1