### PR TITLE
Add toast for match request and filter out rejected matches

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/advisor/AdvisorDashboardController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/advisor/AdvisorDashboardController.java
@@ -40,13 +40,9 @@ public class AdvisorDashboardController {
         long completedProjectCount =
                 projectRepository.countByAdvisorAndStatus(advisor, ProjectStatus.COMPLETED);
 
-        int matchCount = matchRepository.findByAdvisor(advisor).size();
+        var matches = matchRepository.findByAdvisorAndStatusNot(advisor, MatchStatus.REJECTED);
+        int matchCount = matches.size();
         int projectCount = projectRepository.findByAdvisor(advisor).size();
-
-        var matches = matchRepository.findByAdvisor(advisor)
-                        .stream()
-                        .filter(m -> m.getStatus() != MatchStatus.COMPLETED)
-                        .toList();
         for (var m : matches) {
                 boolean noneActive = projectRepository
                                 .findByStudentAndAdvisorAndStatus(m.getStudent(), advisor,

--- a/src/main/java/com/uanl/asesormatch/repository/MatchRepository.java
+++ b/src/main/java/com/uanl/asesormatch/repository/MatchRepository.java
@@ -9,7 +9,9 @@ import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.enums.MatchStatus;
 
 public interface MatchRepository extends JpaRepository<Match, Long> {
-	List<Match> findByStudent(User student);
+        List<Match> findByStudent(User student);
+
+        List<Match> findByStudentAndStatusNot(User student, MatchStatus status);
 
         boolean existsByStudentIdAndAdvisorIdAndStatus(Long studentId, Long advisorId, MatchStatus status);
 
@@ -18,6 +20,8 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
         boolean existsByStudentIdAndAdvisorId(Long studentId, Long advisorId);
 
         List<Match> findByAdvisor(User advisor);
+
+        List<Match> findByAdvisorAndStatusNot(User advisor, MatchStatus status);
 
         List<Match> findByAdvisorAndStatus(User advisor, MatchStatus accepted);
 

--- a/src/main/java/com/uanl/asesormatch/service/MatchingService.java
+++ b/src/main/java/com/uanl/asesormatch/service/MatchingService.java
@@ -58,9 +58,10 @@ public class MatchingService {
 		return matches;
 	}
 
-	public List<Match> getMatchesForStudent(User student) {
-		return matchRepository.findByStudent(student);
-	}
+        public List<Match> getMatchesForStudent(User student) {
+                return matchRepository
+                                .findByStudentAndStatusNot(student, MatchStatus.REJECTED);
+        }
 
 	public void updateMatchStatus(Long matchId, MatchStatus status) {
 		var matchOpt = matchRepository.findById(matchId);

--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -48,7 +48,7 @@
 				</tr>
 			</thead>
 			<tbody>
-				<tr th:each="match : ${matches}">
+                                <tr th:each="match : ${matches}" th:if="${match.status.name() != 'REJECTED'}">
 					<td th:text="${match.student.fullName}">Student Name</td>
 					<td
 						th:text="${T(java.lang.Math).round(match.compatibilityScore * 100)} + '%'">0%</td>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -138,7 +138,7 @@
 							</tr>
 						</thead>
 						<tbody>
-							<tr th:each="match : ${matches}">
+                                                        <tr th:each="match : ${matches}" th:if="${match.status.name() != 'REJECTED'}">
 								<td><a href="#" class="view-profile"
 									th:data-advisor-id="${match.advisor.id}"
 									th:text="${match.advisor.fullName}">Advisor</a></td>
@@ -199,9 +199,19 @@
 		</div>
 
 		<div th:replace="~{fragments/advisorFragments :: profileModal}"></div>
-		<div th:replace="~{fragments/advisorFragments :: matchModal}"></div>
-		<div th:replace="~{fragments/advisorFragments :: feedbackModal}"></div>
-	</div>
+                <div th:replace="~{fragments/advisorFragments :: matchModal}"></div>
+                <div th:replace="~{fragments/advisorFragments :: feedbackModal}"></div>
+                <div class="toast-container position-fixed top-0 end-0 p-3">
+                    <div id="matchToast" class="toast align-items-center text-bg-success" role="alert" aria-live="assertive" aria-atomic="true">
+                        <div class="d-flex">
+                            <div class="toast-body">
+                                Match request sent. Please wait for the advisor to accept or reject your request.
+                            </div>
+                            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+                        </div>
+                    </div>
+                </div>
+        </div>
         <script>
         document.addEventListener('DOMContentLoaded', function() {
         const initialTab = /*[[${activeTab}]]*/ '';
@@ -353,6 +363,17 @@
         });
 
         const params = new URLSearchParams(window.location.search);
+        if (params.has('matchRequested')) {
+            const toastEl = document.getElementById('matchToast');
+            if (toastEl) {
+                new bootstrap.Toast(toastEl).show();
+                toastEl.addEventListener('hidden.bs.toast', () => {
+                    params.delete('matchRequested');
+                    const q = params.toString();
+                    history.replaceState(null, '', window.location.pathname + (q ? '?' + q : ''));
+                });
+            }
+        }
         const feedbackModalEl = document.getElementById('feedbackModal');
         if (feedbackModalEl) {
             feedbackModalEl.addEventListener('hidden.bs.modal', () => {


### PR DESCRIPTION
## Summary
- filter match queries in `MatchRepository`
- exclude `REJECTED` matches when retrieving student matches
- hide rejected matches from advisor dashboard in backend and view
- show success toast when a match request is submitted

## Testing
- `./mvnw -q test` *(fails: Unable to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_687d4fb4c7248320937fe10ea1a938dc