### PR TITLE
Ensure entity scan for DataJpaTest

### DIFF
--- a/src/test/java/com/uanl/asesormatch/config/TestEntityScanConfig.java
+++ b/src/test/java/com/uanl/asesormatch/config/TestEntityScanConfig.java
@@ -1,0 +1,9 @@
+package com.uanl.asesormatch.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+
+@TestConfiguration
+@EntityScan("com.uanl.asesormatch.entity")
+public class TestEntityScanConfig {
+}

--- a/src/test/java/com/uanl/asesormatch/service/AdvisorServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/AdvisorServiceTests.java
@@ -9,12 +9,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.uanl.asesormatch.config.TestEntityScanConfig;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@Import(TestEntityScanConfig.class)
 class AdvisorServiceTests {
 	@Autowired
 	private UserRepository userRepository;

--- a/src/test/java/com/uanl/asesormatch/service/FeedbackServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/FeedbackServiceTests.java
@@ -12,10 +12,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.uanl.asesormatch.config.TestEntityScanConfig;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@Import(TestEntityScanConfig.class)
 class FeedbackServiceTests {
     @Autowired
     private ProjectRepository projectRepository;

--- a/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
@@ -14,6 +14,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.uanl.asesormatch.config.TestEntityScanConfig;
 
 import java.util.List;
 
@@ -22,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
+@Import(TestEntityScanConfig.class)
 class MatchingServiceTests {
 
 	@Autowired

--- a/src/test/java/com/uanl/asesormatch/service/NotificationServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/NotificationServiceTests.java
@@ -9,12 +9,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.uanl.asesormatch.config.TestEntityScanConfig;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@Import(TestEntityScanConfig.class)
 class NotificationServiceTests {
 	@Autowired
 	private NotificationRepository notificationRepository;

--- a/src/test/java/com/uanl/asesormatch/service/ProjectAssignmentTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/ProjectAssignmentTests.java
@@ -13,10 +13,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.uanl.asesormatch.config.TestEntityScanConfig;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@Import(TestEntityScanConfig.class)
 class ProjectAssignmentTests {
     @Autowired
     private ProjectRepository projectRepository;

--- a/src/test/java/com/uanl/asesormatch/service/ProjectDeletionTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/ProjectDeletionTests.java
@@ -9,10 +9,14 @@ import com.uanl.asesormatch.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.uanl.asesormatch.config.TestEntityScanConfig;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@Import(TestEntityScanConfig.class)
 class ProjectDeletionTests {
     @Autowired
     private ProjectRepository projectRepository;

--- a/src/test/java/com/uanl/asesormatch/service/StoryServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/StoryServiceTests.java
@@ -13,10 +13,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.uanl.asesormatch.config.TestEntityScanConfig;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@Import(TestEntityScanConfig.class)
 class StoryServiceTests {
     @Autowired
     private StoryRepository storyRepository;

--- a/src/test/java/com/uanl/asesormatch/service/StudentServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/StudentServiceTests.java
@@ -12,6 +12,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.uanl.asesormatch.config.TestEntityScanConfig;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +23,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@Import(TestEntityScanConfig.class)
 class StudentServiceTests {
 	@Autowired
 	private UserRepository userRepository;


### PR DESCRIPTION
## Summary
- add `TestEntityScanConfig` so tests can detect JPA entities
- import this config in all `@DataJpaTest` classes

## Testing
- `./mvnw -q test` *(fails: unable to download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687d51c9c8348320b193602d83b866b2