### PR TITLE
Fix JPA tests by creating schema

### DIFF
--- a/src/test/java/com/uanl/asesormatch/service/AdvisorServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/AdvisorServiceTests.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 @Import(TestEntityScanConfig.class)
 class AdvisorServiceTests {
 	@Autowired

--- a/src/test/java/com/uanl/asesormatch/service/FeedbackServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/FeedbackServiceTests.java
@@ -18,7 +18,7 @@ import com.uanl.asesormatch.config.TestEntityScanConfig;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 @Import(TestEntityScanConfig.class)
 class FeedbackServiceTests {
     @Autowired

--- a/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DataJpaTest
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 @Import(TestEntityScanConfig.class)
 class MatchingServiceTests {
 

--- a/src/test/java/com/uanl/asesormatch/service/NotificationServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/NotificationServiceTests.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 @Import(TestEntityScanConfig.class)
 class NotificationServiceTests {
 	@Autowired

--- a/src/test/java/com/uanl/asesormatch/service/ProjectAssignmentTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/ProjectAssignmentTests.java
@@ -19,7 +19,7 @@ import com.uanl.asesormatch.config.TestEntityScanConfig;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 @Import(TestEntityScanConfig.class)
 class ProjectAssignmentTests {
     @Autowired

--- a/src/test/java/com/uanl/asesormatch/service/ProjectDeletionTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/ProjectDeletionTests.java
@@ -15,7 +15,7 @@ import com.uanl.asesormatch.config.TestEntityScanConfig;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 @Import(TestEntityScanConfig.class)
 class ProjectDeletionTests {
     @Autowired

--- a/src/test/java/com/uanl/asesormatch/service/StoryServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/StoryServiceTests.java
@@ -19,7 +19,7 @@ import com.uanl.asesormatch.config.TestEntityScanConfig;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 @Import(TestEntityScanConfig.class)
 class StoryServiceTests {
     @Autowired

--- a/src/test/java/com/uanl/asesormatch/service/StudentServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/StudentServiceTests.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 @Import(TestEntityScanConfig.class)
 class StudentServiceTests {
 	@Autowired


### PR DESCRIPTION
## Summary
- ensure that entities are created in the H2 database during tests
- update all `@DataJpaTest` annotations so Hibernate creates tables before running tests

## Testing
- `./mvnw -q test` *(fails: Could not download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687d5c41128883208e94918aa2d31349