### PR TITLE
Translate Spanish strings to English

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/ProjectController.java
@@ -144,9 +144,9 @@ public class ProjectController {
                         p.setStatus(ProjectStatus.COMPLETED);
                         projectRepository.save(p);
                         String url = "/dashboard?feedbackProjectId=" + p.getId();
-                        String msg = "Tu proyecto '" + p.getTitle()
-                                        + "' fue marcado como completado. Por favor da tu feedback. <a href='"
-                                        + url + "'>aquí</a>";
+                        String msg = "Your project '" + p.getTitle()
+                                        + "' was marked as completed. Please provide your feedback <a href='"
+                                        + url + "'>here</a>";
                         notificationService.notify(match.getStudent(), msg);
                 }
 
@@ -171,9 +171,9 @@ public class ProjectController {
                                         .findFirst();
                         matchOpt.ifPresent(m -> {
                                 String url = "/dashboard?feedbackProjectId=" + project.getId();
-                                String msg = "Tu proyecto '" + project.getTitle()
-                                                + "' fue marcado como completado. Por favor da tu feedback. <a href='"
-                                                + url + "'>aquí</a>";
+                                String msg = "Your project '" + project.getTitle()
+                                                + "' was marked as completed. Please provide your feedback <a href='"
+                                                + url + "'>here</a>";
                                 notificationService.notify(m.getStudent(), msg);
                         });
                         return matchOpt.isPresent()

--- a/src/main/java/com/uanl/asesormatch/controller/StoryController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/StoryController.java
@@ -62,7 +62,7 @@ public class StoryController {
         }
         storyService.createStory(project, user, title, description);
         if (!project.getStudent().getId().equals(user.getId())) {
-            String msg = "El maestro ha agregado una story a tu proyecto (" +
+            String msg = "The advisor added a story to your project (" +
                     project.getTitle() + "): " + title + ".";
             notificationService.notify(project.getStudent(), msg);
         }

--- a/src/main/java/com/uanl/asesormatch/service/FeedbackService.java
+++ b/src/main/java/com/uanl/asesormatch/service/FeedbackService.java
@@ -62,8 +62,8 @@ public class FeedbackService {
             String url = otherUser.getRole() == Role.ADVISOR
                     ? "/advisor-dashboard?feedbackProjectId=" + projectId
                     : "/dashboard?feedbackProjectId=" + projectId;
-            String msg = "El otro participante ya env\u00EDo su feedback para el proyecto '"
-                    + project.getTitle() + "'. Por favor da el tuyo <a href='" + url + "'>aqu\u00ED</a>";
+            String msg = "The other participant has already submitted their feedback for project '"
+                    + project.getTitle() + "'. Please provide yours <a href='" + url + "'>here</a>";
             notificationService.notify(otherUser, msg);
         }
     }

--- a/src/main/java/com/uanl/asesormatch/service/MatchingService.java
+++ b/src/main/java/com/uanl/asesormatch/service/MatchingService.java
@@ -79,12 +79,12 @@ public class MatchingService {
                                         }
                                 }
 
-				String msg = "El maestro " + m.getAdvisor().getFullName() + " aprob\u00F3 ser tu tutor.";
-				notificationService.notify(m.getStudent(), msg);
-			} else if (status == MatchStatus.REJECTED) {
-				String msg = "El maestro " + m.getAdvisor().getFullName() + " no acept\u00F3 ser tu tutor.";
-				notificationService.notify(m.getStudent(), msg);
-			}
+                                String msg = "Advisor " + m.getAdvisor().getFullName() + " agreed to be your mentor.";
+                                notificationService.notify(m.getStudent(), msg);
+                        } else if (status == MatchStatus.REJECTED) {
+                                String msg = "Advisor " + m.getAdvisor().getFullName() + " declined to be your mentor.";
+                                notificationService.notify(m.getStudent(), msg);
+                        }
 		});
 	}
 

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -354,7 +354,7 @@
                 const data = await res.json();
 
                 if (data.noDraftProjects) {
-                    content.innerHTML = '<div class="alert alert-warning">No puedes emparejarte con un maestro porque no tienes proyectos disponibles.</div>';
+                    content.innerHTML = '<div class="alert alert-warning">You cannot request a match because you have no available projects.</div>';
                 } else {
                     content.innerHTML = buildRecommendationsTable(data.recommendations || []);
                     content.insertAdjacentHTML('beforeend', buildNewRecommendationsList(data.newRecommendations || []));

--- a/src/main/resources/templates/fragments/advisorFragments.html
+++ b/src/main/resources/templates/fragments/advisorFragments.html
@@ -97,16 +97,16 @@
 						</div>
                                                 <div class="modal-body">
                                                         <p class="small text-muted mb-3">
-                                                                Estos comentarios nos ayudaran a mejorar nuestro sistema de emparejamiento.
-                                                                ¿cómo te sentiste de trabajar con
+                                                                These comments help us improve our matching system.
+                                                                How did you feel working with
                                                                 <strong id="feedbackOtherName" th:text="${feedbackOtherName}"></strong>
-                                                                en el proyecto <strong id="feedbackProjectTitle" th:text="${feedbackProjectTitle}"></strong>?
+                                                                on the project <strong id="feedbackProjectTitle" th:text="${feedbackProjectTitle}"></strong>?
                                                         </p>
                                                         <div id="otherFeedback" class="alert alert-info d-none">
-                                                                El otro usuario ya envió su feedback.
+                                                                The other user already submitted their feedback.
                                                         </div>
                                                         <div id="myFeedbackDisplay" class="alert alert-success d-none">
-                                                                Gracias por enviar tu feedback.
+                                                                Thanks for submitting your feedback.
                                                         </div>
                                                         <div id="myFeedbackForm">
                                                                 <div class="mb-3">

--- a/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
+++ b/src/test/java/com/uanl/asesormatch/service/MatchingServiceTests.java
@@ -112,8 +112,8 @@ class MatchingServiceTests {
 
 		var notifications = notificationRepository.findByUserOrderByCreatedAtDesc(student);
 		assertEquals(1, notifications.size());
-		String msg = notifications.get(0).getMessage();
-		assertEquals("El maestro " + advisor.getFullName() + " no acept\u00F3 ser tu tutor.", msg);
+                String msg = notifications.get(0).getMessage();
+                assertEquals("Advisor " + advisor.getFullName() + " declined to be your mentor.", msg);
 	}
 
 	@Test
@@ -160,8 +160,8 @@ class MatchingServiceTests {
 
 		var notifications = notificationRepository.findByUserOrderByCreatedAtDesc(student);
 		assertEquals(1, notifications.size());
-		String msg = notifications.get(0).getMessage();
-		assertEquals("El maestro " + advisor1.getFullName() + " aprob\u00F3 ser tu tutor.", msg);
+                String msg = notifications.get(0).getMessage();
+                assertEquals("Advisor " + advisor1.getFullName() + " agreed to be your mentor.", msg);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- convert Spanish alert for missing projects to English
- translate text in feedback modal
- translate notification messages in StoryController, ProjectController, MatchingService, and FeedbackService
- adjust tests for updated messages

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_687d66347ae883208d98f7574cf90675