### PR TITLE
Add real-time notifications with SSE

### DIFF
--- a/src/main/java/com/uanl/asesormatch/controller/NotificationController.java
+++ b/src/main/java/com/uanl/asesormatch/controller/NotificationController.java
@@ -8,9 +8,11 @@ import com.uanl.asesormatch.config.AdvisorEmailProvider;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Controller
 @RequestMapping("/notification")
@@ -18,13 +20,16 @@ public class NotificationController {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
     private final AdvisorEmailProvider emailProvider;
+    private final com.uanl.asesormatch.service.NotificationService notificationService;
 
     public NotificationController(NotificationRepository notificationRepository,
                                   UserRepository userRepository,
-                                  AdvisorEmailProvider emailProvider) {
+                                  AdvisorEmailProvider emailProvider,
+                                  com.uanl.asesormatch.service.NotificationService notificationService) {
         this.notificationRepository = notificationRepository;
         this.userRepository = userRepository;
         this.emailProvider = emailProvider;
+        this.notificationService = notificationService;
     }
 
     @PostMapping("/delete")
@@ -36,5 +41,11 @@ public class NotificationController {
             notificationRepository.delete(n);
         }
         return "redirect:/dashboard";
+    }
+
+    @GetMapping("/stream")
+    public SseEmitter stream(@AuthenticationPrincipal OidcUser oidcUser) {
+        User user = userRepository.findByEmail(emailProvider.resolveEmail(oidcUser)).orElseThrow();
+        return notificationService.register(user.getId());
     }
 }

--- a/src/main/java/com/uanl/asesormatch/service/NotificationService.java
+++ b/src/main/java/com/uanl/asesormatch/service/NotificationService.java
@@ -4,13 +4,19 @@ import com.uanl.asesormatch.entity.Notification;
 import com.uanl.asesormatch.entity.User;
 import com.uanl.asesormatch.repository.NotificationRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Service
 public class NotificationService {
     private final NotificationRepository repo;
+    private final Map<Long, CopyOnWriteArrayList<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
     public NotificationService(NotificationRepository repo) {
         this.repo = repo;
@@ -23,9 +29,42 @@ public class NotificationService {
         n.setCreatedAt(LocalDateTime.now());
         n.setRead(false);
         repo.save(n);
+        sendEvent(user.getId(), n);
     }
 
     public List<Notification> getNotificationsFor(User user) {
         return repo.findByUserOrderByCreatedAtDesc(user);
     }
+
+    public SseEmitter register(Long userId) {
+        SseEmitter emitter = new SseEmitter(0L);
+        emitters.computeIfAbsent(userId, k -> new CopyOnWriteArrayList<>()).add(emitter);
+        emitter.onCompletion(() -> removeEmitter(userId, emitter));
+        emitter.onTimeout(() -> removeEmitter(userId, emitter));
+        return emitter;
+    }
+
+    private void removeEmitter(Long userId, SseEmitter emitter) {
+        var list = emitters.get(userId);
+        if (list != null) {
+            list.remove(emitter);
+        }
+    }
+
+    private void sendEvent(Long userId, Notification notification) {
+        var list = emitters.get(userId);
+        if (list != null) {
+            for (SseEmitter emitter : list) {
+                try {
+                    emitter.send(SseEmitter.event()
+                            .name("notification")
+                            .data(new NotificationDTO(notification.getId(), notification.getMessage())));
+                } catch (IOException ex) {
+                    removeEmitter(userId, emitter);
+                }
+            }
+        }
+    }
+
+    public record NotificationDTO(Long id, String message) {}
 }

--- a/src/main/resources/static/js/notifications.js
+++ b/src/main/resources/static/js/notifications.js
@@ -1,0 +1,34 @@
+(function(){
+    document.addEventListener('DOMContentLoaded', function(){
+        if (!window.EventSource) return;
+        const container = document.getElementById('notificationsContainer');
+        const evtSource = new EventSource('/notification/stream');
+        evtSource.addEventListener('notification', function(e){
+            const data = JSON.parse(e.data);
+            addNotification(data.id, data.message);
+        });
+        function addNotification(id, message){
+            let cont = document.getElementById('notificationsContainer');
+            if(!cont){
+                cont = document.createElement('div');
+                cont.id = 'notificationsContainer';
+                cont.className = 'toast-container position-fixed top-0 end-0 p-3';
+                document.body.appendChild(cont);
+            }
+            const wrapper = document.createElement('div');
+            wrapper.className = 'toast align-items-center text-bg-info';
+            wrapper.setAttribute('data-bs-autohide','false');
+            wrapper.innerHTML =
+                '<div class="d-flex">' +
+                '<div class="toast-body"><span>'+message+'</span></div>' +
+                '<form action="/notification/delete" method="post" style="display:inline;">' +
+                '<input type="hidden" name="id" value="'+id+'" />' +
+                '<button type="submit" class="btn-close btn-close-white me-2 m-auto" aria-label="Close"></button>' +
+                '</form>' +
+                '</div>';
+            cont.appendChild(wrapper);
+            new bootstrap.Toast(wrapper).show();
+        }
+    });
+})();
+

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -24,9 +24,9 @@
 				</p>
 			</div>
 		</div>
-                <div th:if="${notifications != null and !#lists.isEmpty(notifications)}"
-                     id="notificationsContainer"
-                     class="toast-container position-fixed top-0 end-0 p-3">
+                <div id="notificationsContainer"
+                     class="toast-container position-fixed top-0 end-0 p-3"
+                     th:classappend="${notifications == null or #lists.isEmpty(notifications)} ? ' d-none'">
                     <div class="toast align-items-center text-bg-info" th:each="n : ${notifications}"
                          role="alert" aria-live="assertive" aria-atomic="true" data-bs-autohide="false">
                         <div class="d-flex">

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -26,8 +26,9 @@
 			</div>
 		</div>
 	</nav>
-	<main class="container" th:replace="${content}"></main>
-	<script
-		src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+        <main class="container" th:replace="${content}"></main>
+        <script
+                src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+        <script th:src="@{/js/notifications.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow `NotificationService` to register SSE clients and push updates
- expose `/notification/stream` endpoint to return an `SseEmitter`
- include notification streaming script
- always render notification container
- attach notifications script in layout

## Testing
- `./mvnw -q test` *(fails: repo.maven.apache.org unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687d68a3a71c8320a6cb954a77ccd81c