### PR TITLE
Use 'Task' terminology on Story pages

### DIFF
--- a/src/main/resources/templates/advisor-dashboard.html
+++ b/src/main/resources/templates/advisor-dashboard.html
@@ -100,7 +100,7 @@
 						<th>Student</th>
 						<th>Status</th>
 						<th>Start Date</th>
-						<th>Stories</th>
+						<th>Tasks</th>
 						<th>Actions</th>
 					</tr>
 				</thead>
@@ -133,7 +133,7 @@
 						<td th:text="${p.status}">IN_PROGRESS</td>
 						<td th:text="${#temporals.format(p.startDate, 'dd/MM/yyyy')}">2025-06-28</td>
 						<td><a th:href="@{/story/list(projectId=${p.id})}"
-							class="btn btn-outline-secondary btn-sm">View Stories</a></td>
+							class="btn btn-outline-secondary btn-sm">View Tasks</a></td>
 						<td>
 							<form th:if="${p.status.name() == 'IN_PROGRESS'}"
 								th:action="@{/project/complete-project}" method="post"

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -174,7 +174,7 @@
 								<th>Title</th>
 								<th>Description</th>
 								<th>Status</th>
-								<th>Stories</th>
+								<th>Tasks</th>
 								<th></th>
 							</tr>
 						</thead>
@@ -186,7 +186,7 @@
 								<td th:text="${p.status}">Status</td>
 								<td><a th:if="${p.status.name() == 'IN_PROGRESS'}"
 									th:href="@{/story/list(projectId=${p.id})}"
-									class="btn btn-outline-secondary btn-sm">View Stories</a></td>
+									class="btn btn-outline-secondary btn-sm">View Tasks</a></td>
 								<td>
 									<form th:action="@{/project/delete}" method="post"
 										th:if="${p.status.name() != 'IN_PROGRESS'}"

--- a/src/main/resources/templates/fragments/advisorFragments.html
+++ b/src/main/resources/templates/fragments/advisorFragments.html
@@ -144,8 +144,8 @@
 							<h5 class="modal-title">Warning</h5>
 							<button type="button" class="btn-close" data-bs-dismiss="modal"></button>
 						</div>
-						<div class="modal-body">This project still has stories
-							pending.</div>
+                                                <div class="modal-body">This project still has tasks
+                                                        pending.</div>
 						<div class="modal-footer">
 							<button type="button" class="btn btn-secondary"
 								data-bs-dismiss="modal">Close</button>

--- a/src/main/resources/templates/project-detail.html
+++ b/src/main/resources/templates/project-detail.html
@@ -17,7 +17,7 @@
 			<strong>Advisor:</strong> <span th:text="${project.advisor.fullName}">Advisor</span>
 		</p>
 		<a th:href="@{/story/list(projectId=${project.id})}"
-			class="btn btn-outline-secondary mt-3">View Stories</a>
+			class="btn btn-outline-secondary mt-3">View Tasks</a>
 	</div>
 </body>
 </html>

--- a/src/main/resources/templates/project-stories.html
+++ b/src/main/resources/templates/project-stories.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-	th:replace="~{layout :: layout(~{::body}, 'Project Stories')}">
+	th:replace="~{layout :: layout(~{::body}, 'Project Tasks')}">
 <body>
 	<div class="container my-4">
 		<div
@@ -16,7 +16,7 @@
 				<label class="form-label">Description</label>
 				<textarea class="form-control" name="description" rows="3"></textarea>
 			</div>
-			<button class="btn btn-primary" type="submit">Add Story</button>
+			<button class="btn btn-primary" type="submit">Add Task</button>
 		</form>
 		<table class="table">
 			<thead>


### PR DESCRIPTION
## Summary
- Update dashboard and advisor dashboard to show "Tasks" and "View Tasks"
- Rename project story pages to "Project Tasks" and change buttons to "Add Task"
- Adjust modal to warn about pending tasks instead of stories

## Testing
- `./mvnw test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_6892b77a9a748320948eb3164313f18e