### PR TITLE
Ensure unique notification timestamps and configure test profile

### DIFF
--- a/src/main/java/com/uanl/asesormatch/service/MatchingService.java
+++ b/src/main/java/com/uanl/asesormatch/service/MatchingService.java
@@ -107,15 +107,19 @@ public class MatchingService {
 		});
 	}
 
-	public void requestMatch(Long studentId, Long advisorId, Double score) {
-		logger.info("Student {} requesting advisor {} with score {}", studentId, advisorId, score);
-		User student = userRepository.findById(studentId).orElseThrow(() -> new IllegalArgumentException("student"));
-		User advisor = userRepository.findById(advisorId).orElseThrow(() -> new IllegalArgumentException("advisor"));
+        public void requestMatch(Long studentId, Long advisorId, Double score) {
+                logger.info("Student {} requesting advisor {} with score {}", studentId, advisorId, score);
+                User student = userRepository.findById(studentId).orElseThrow(() -> new IllegalArgumentException("student"));
+                User advisor = userRepository.findById(advisorId).orElseThrow(() -> new IllegalArgumentException("advisor"));
 
-		boolean hasDraft = projectRepository.existsByStudentAndStatus(student, ProjectStatus.DRAFT);
-		if (!hasDraft) {
-			throw new IllegalStateException("student has no draft projects");
-		}
+                // Ensure previously saved entities are written so existence checks see them
+                projectRepository.flush();
+                matchRepository.flush();
+
+                boolean hasDraft = projectRepository.existsByStudentAndStatus(student, ProjectStatus.DRAFT);
+                if (!hasDraft) {
+                        throw new IllegalStateException("student has no draft projects");
+                }
 
 		boolean ongoingProject = projectRepository.existsByStudentAndStatus(student, ProjectStatus.IN_PROGRESS);
 		if (ongoingProject) {

--- a/src/main/java/com/uanl/asesormatch/service/MatchingService.java
+++ b/src/main/java/com/uanl/asesormatch/service/MatchingService.java
@@ -65,20 +65,20 @@ public class MatchingService {
 		return matches;
 	}
 
-        public List<Match> getMatchesForStudent(User student) {
-                return matchRepository.findByStudentAndStatusNot(student, MatchStatus.REJECTED);
-        }
+	public List<Match> getMatchesForStudent(User student) {
+		return matchRepository.findByStudentAndStatusNot(student, MatchStatus.REJECTED);
+	}
 
-        public double computeCompatibility(Set<String> studentInterests, Set<String> advisorAreas) {
-                if (studentInterests == null || studentInterests.isEmpty()) {
-                        return 0.0;
-                }
-                if (advisorAreas == null) {
-                        advisorAreas = Set.of();
-                }
-                long matches = studentInterests.stream().filter(advisorAreas::contains).count();
-                return (double) matches / studentInterests.size();
-        }
+	public double computeCompatibility(Set<String> studentInterests, Set<String> advisorAreas) {
+		if (studentInterests == null || studentInterests.isEmpty()) {
+			return 0.0;
+		}
+		if (advisorAreas == null) {
+			advisorAreas = Set.of();
+		}
+		long matches = studentInterests.stream().filter(advisorAreas::contains).count();
+		return (double) matches / studentInterests.size();
+	}
 
 	public void updateMatchStatus(Long matchId, MatchStatus status) {
 		logger.info("Updating match {} to status {}", matchId, status);

--- a/src/main/java/com/uanl/asesormatch/service/MatchingService.java
+++ b/src/main/java/com/uanl/asesormatch/service/MatchingService.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 public class MatchingService {
@@ -64,9 +65,20 @@ public class MatchingService {
 		return matches;
 	}
 
-	public List<Match> getMatchesForStudent(User student) {
-		return matchRepository.findByStudentAndStatusNot(student, MatchStatus.REJECTED);
-	}
+        public List<Match> getMatchesForStudent(User student) {
+                return matchRepository.findByStudentAndStatusNot(student, MatchStatus.REJECTED);
+        }
+
+        public double computeCompatibility(Set<String> studentInterests, Set<String> advisorAreas) {
+                if (studentInterests == null || studentInterests.isEmpty()) {
+                        return 0.0;
+                }
+                if (advisorAreas == null) {
+                        advisorAreas = Set.of();
+                }
+                long matches = studentInterests.stream().filter(advisorAreas::contains).count();
+                return (double) matches / studentInterests.size();
+        }
 
 	public void updateMatchStatus(Long matchId, MatchStatus status) {
 		logger.info("Updating match {} to status {}", matchId, status);

--- a/src/main/java/com/uanl/asesormatch/service/MatchingService.java
+++ b/src/main/java/com/uanl/asesormatch/service/MatchingService.java
@@ -65,20 +65,9 @@ public class MatchingService {
 		return matches;
 	}
 
-        public List<Match> getMatchesForStudent(User student) {
-                return matchRepository.findByStudentAndStatusNot(student, MatchStatus.REJECTED);
-        }
-
-        public double computeCompatibility(Set<String> studentInterests, Set<String> advisorAreas) {
-                if (studentInterests == null || studentInterests.isEmpty()) {
-                        return 0.0;
-                }
-                if (advisorAreas == null) {
-                        advisorAreas = Set.of();
-                }
-                long matches = studentInterests.stream().filter(advisorAreas::contains).count();
-                return (double) matches / studentInterests.size();
-        }
+	public List<Match> getMatchesForStudent(User student) {
+		return matchRepository.findByStudentAndStatusNot(student, MatchStatus.REJECTED);
+	}
 
 	public double computeCompatibility(Set<String> studentInterests, Set<String> advisorAreas) {
 		if (studentInterests == null || studentInterests.isEmpty()) {

--- a/src/main/java/com/uanl/asesormatch/service/NotificationService.java
+++ b/src/main/java/com/uanl/asesormatch/service/NotificationService.java
@@ -6,13 +6,16 @@ import com.uanl.asesormatch.repository.NotificationRepository;
 import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 @Service
 public class NotificationService {
-	private final NotificationRepository repo;
-	private static final Logger logger = LogManager.getLogger(NotificationService.class);
+        private final NotificationRepository repo;
+        private static final Logger logger = LogManager.getLogger(NotificationService.class);
+        // Ensures unique timestamps when notifications are saved in quick succession
+        private static final AtomicLong counter = new AtomicLong();
 
 	public NotificationService(NotificationRepository repo) {
 		this.repo = repo;
@@ -23,7 +26,8 @@ public class NotificationService {
 		Notification n = new Notification();
 		n.setUser(user);
 		n.setMessage(message);
-		n.setCreatedAt(LocalDateTime.now());
+                // Add a small incremental value so two rapid notifications have distinct timestamps
+                n.setCreatedAt(LocalDateTime.now().plusNanos(counter.getAndIncrement()));
 		n.setRead(false);
 		repo.save(n);
 	}

--- a/src/main/java/com/uanl/asesormatch/service/ProfileService.java
+++ b/src/main/java/com/uanl/asesormatch/service/ProfileService.java
@@ -1,0 +1,53 @@
+package com.uanl.asesormatch.service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.uanl.asesormatch.entity.Profile;
+import com.uanl.asesormatch.repository.ProfileRepository;
+
+@Service
+public class ProfileService {
+
+        private final ProfileRepository profileRepository;
+
+        public ProfileService(ProfileRepository profileRepository) {
+                this.profileRepository = profileRepository;
+        }
+
+        public Profile addInterests(Long profileId, List<String> interests) {
+                var profileOpt = profileRepository.findById(profileId);
+                if (profileOpt.isEmpty()) {
+                        return null;
+                }
+                Profile profile = profileOpt.get();
+                Set<String> normalized = interests.stream()
+                                .map(s -> s == null ? "" : s.trim().toLowerCase())
+                                .filter(s -> !s.isEmpty())
+                                .collect(Collectors.toCollection(LinkedHashSet::new));
+                profile.setInterests(new ArrayList<>(normalized));
+                return profileRepository.save(profile);
+        }
+
+        public Profile addAreas(Long profileId, List<String> areas) {
+                var profileOpt = profileRepository.findById(profileId);
+                if (profileOpt.isEmpty()) {
+                        return null;
+                }
+                Profile profile = profileOpt.get();
+                Set<String> dedup = new LinkedHashSet<>();
+                for (String area : areas) {
+                        if (area != null) {
+                                dedup.add(area.trim());
+                        }
+                }
+                profile.setAreas(new ArrayList<>(dedup));
+                return profileRepository.save(profile);
+        }
+}
+

--- a/src/test/java/com/uanl/asesormatch/AsesormatchApplicationTests.java
+++ b/src/test/java/com/uanl/asesormatch/AsesormatchApplicationTests.java
@@ -2,8 +2,10 @@ package com.uanl.asesormatch;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class AsesormatchApplicationTests {
 
 	@Test

--- a/src/test/java/com/uanl/asesormatch/service/MatchingServiceCompatibilityTest.java
+++ b/src/test/java/com/uanl/asesormatch/service/MatchingServiceCompatibilityTest.java
@@ -1,0 +1,49 @@
+package com.uanl.asesormatch.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.uanl.asesormatch.repository.MatchRepository;
+import com.uanl.asesormatch.repository.ProjectRepository;
+import com.uanl.asesormatch.repository.UserRepository;
+import com.uanl.asesormatch.repository.NotificationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MatchingServiceCompatibilityTest {
+
+        @Mock
+        private MatchRepository matchRepository;
+        @Mock
+        private UserRepository userRepository;
+        @Mock
+        private ProjectRepository projectRepository;
+        @Mock
+        private NotificationRepository notificationRepository;
+
+        private MatchingService matchingService;
+
+        @BeforeEach
+        void setup() {
+                NotificationService notificationService = new NotificationService(notificationRepository);
+                matchingService = new MatchingService(matchRepository, userRepository, projectRepository, notificationService);
+        }
+
+        @Test
+        void computeCompatibility_totalPartialZero() {
+                double full = matchingService.computeCompatibility(Set.of("IA", "Cloud"), Set.of("IA", "Cloud"));
+                double half = matchingService.computeCompatibility(Set.of("IA", "Cloud"), Set.of("IA"));
+                double zero = matchingService.computeCompatibility(Set.of("IA", "Cloud"), Set.of("SQL"));
+
+                assertThat(full).isBetween(0.99, 1.01);
+                assertThat(half).isBetween(0.49, 0.51);
+                assertThat(zero).isEqualTo(0.0);
+        }
+}
+

--- a/src/test/java/com/uanl/asesormatch/service/MatchingServiceStatusTest.java
+++ b/src/test/java/com/uanl/asesormatch/service/MatchingServiceStatusTest.java
@@ -1,0 +1,81 @@
+package com.uanl.asesormatch.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.uanl.asesormatch.entity.Match;
+import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.enums.MatchStatus;
+import com.uanl.asesormatch.repository.MatchRepository;
+import com.uanl.asesormatch.repository.NotificationRepository;
+import com.uanl.asesormatch.repository.ProjectRepository;
+import com.uanl.asesormatch.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MatchingServiceStatusTest {
+
+        @Mock
+        private MatchRepository matchRepo;
+        @Mock
+        private NotificationRepository notificationRepo;
+        @Mock
+        private UserRepository userRepo;
+        @Mock
+        private ProjectRepository projectRepo;
+
+        private MatchingService matchingService;
+
+        @BeforeEach
+        void setup() {
+                NotificationService notificationService = new NotificationService(notificationRepo);
+                matchingService = new MatchingService(matchRepo, userRepo, projectRepo, notificationService);
+        }
+
+        @Test
+        void updateMatchStatus_acceptsOne_rejectsOthersOfSameStudent() {
+                Match chosen = new Match();
+                chosen.setId(100L);
+                User student = new User();
+                student.setId(1L);
+                chosen.setStudent(student);
+                User advisor = new User();
+                advisor.setId(2L);
+                advisor.setFullName("Advisor A");
+                chosen.setAdvisor(advisor);
+                chosen.setStatus(MatchStatus.PENDING);
+
+                Match other1 = new Match();
+                other1.setId(101L);
+                other1.setStudent(student);
+                other1.setStatus(MatchStatus.PENDING);
+
+                Match other2 = new Match();
+                other2.setId(102L);
+                other2.setStudent(student);
+                other2.setStatus(MatchStatus.PENDING);
+
+                when(matchRepo.findById(100L)).thenReturn(Optional.of(chosen));
+                when(matchRepo.findByStudent(student)).thenReturn(List.of(chosen, other1, other2));
+
+                matchingService.updateMatchStatus(100L, MatchStatus.ACCEPTED);
+
+                assertThat(chosen.getStatus()).isEqualTo(MatchStatus.ACCEPTED);
+                assertThat(other1.getStatus()).isEqualTo(MatchStatus.REJECTED);
+                assertThat(other2.getStatus()).isEqualTo(MatchStatus.REJECTED);
+
+                verify(matchRepo, times(1)).save(chosen);
+                verify(matchRepo, times(1)).save(other1);
+                verify(matchRepo, times(1)).save(other2);
+                verify(notificationRepo, atLeastOnce()).save(any());
+        }
+}
+

--- a/src/test/java/com/uanl/asesormatch/service/MatchingServiceStatusTest.java
+++ b/src/test/java/com/uanl/asesormatch/service/MatchingServiceStatusTest.java
@@ -1,0 +1,77 @@
+package com.uanl.asesormatch.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.uanl.asesormatch.entity.Match;
+import com.uanl.asesormatch.entity.User;
+import com.uanl.asesormatch.enums.MatchStatus;
+import com.uanl.asesormatch.repository.MatchRepository;
+import com.uanl.asesormatch.repository.NotificationRepository;
+import com.uanl.asesormatch.repository.ProjectRepository;
+import com.uanl.asesormatch.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MatchingServiceStatusTest {
+
+        @Mock
+        private MatchRepository matchRepo;
+        @Mock
+        private NotificationRepository notificationRepo;
+        @Mock
+        private UserRepository userRepo;
+        @Mock
+        private ProjectRepository projectRepo;
+
+        private MatchingService matchingService;
+
+        @BeforeEach
+        void setup() {
+                NotificationService notificationService = new NotificationService(notificationRepo);
+                matchingService = new MatchingService(matchRepo, userRepo, projectRepo, notificationService);
+        }
+
+        @Test
+        void updateMatchStatus_acceptsOne_rejectsOthersOfSameStudent() {
+                Match chosen = new Match();
+                chosen.setId(100L);
+                User student = new User();
+                student.setId(1L);
+                chosen.setStudent(student);
+                chosen.setStatus(MatchStatus.PENDING);
+
+                Match other1 = new Match();
+                other1.setId(101L);
+                other1.setStudent(student);
+                other1.setStatus(MatchStatus.PENDING);
+
+                Match other2 = new Match();
+                other2.setId(102L);
+                other2.setStudent(student);
+                other2.setStatus(MatchStatus.PENDING);
+
+                when(matchRepo.findById(100L)).thenReturn(Optional.of(chosen));
+                when(matchRepo.findByStudent(student)).thenReturn(List.of(chosen, other1, other2));
+
+                matchingService.updateMatchStatus(100L, MatchStatus.ACCEPTED);
+
+                assertThat(chosen.getStatus()).isEqualTo(MatchStatus.ACCEPTED);
+                assertThat(other1.getStatus()).isEqualTo(MatchStatus.REJECTED);
+                assertThat(other2.getStatus()).isEqualTo(MatchStatus.REJECTED);
+
+                verify(matchRepo, times(1)).save(chosen);
+                verify(matchRepo, times(1)).save(other1);
+                verify(matchRepo, times(1)).save(other2);
+                verify(notificationRepo, atLeastOnce()).save(any());
+        }
+}
+

--- a/src/test/java/com/uanl/asesormatch/service/ProfileServiceTest.java
+++ b/src/test/java/com/uanl/asesormatch/service/ProfileServiceTest.java
@@ -1,0 +1,59 @@
+package com.uanl.asesormatch.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.uanl.asesormatch.entity.Profile;
+import com.uanl.asesormatch.repository.ProfileRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+
+        @Mock
+        ProfileRepository profileRepository;
+
+        ProfileService profileService;
+
+        @BeforeEach
+        void setup() {
+                profileService = new ProfileService(profileRepository);
+        }
+
+        @Test
+        void addInterests_removesDuplicates_andNormalizes() {
+                Profile p = new Profile();
+                p.setId(10L);
+                when(profileRepository.findById(10L)).thenReturn(java.util.Optional.of(p));
+                when(profileRepository.save(any(Profile.class))).thenAnswer(inv -> inv.getArgument(0));
+
+                List<String> input = List.of("IA", "ia", "Cloud", "Cloud ");
+                Profile saved = profileService.addInterests(10L, input);
+
+                Set<String> expected = Set.of("ia", "cloud");
+                assertThat(saved.getInterests()).containsExactlyInAnyOrderElementsOf(expected);
+                verify(profileRepository).save(any(Profile.class));
+        }
+
+        @Test
+        void addAreas_removesDuplicates() {
+                Profile p = new Profile();
+                p.setId(11L);
+                when(profileRepository.findById(11L)).thenReturn(java.util.Optional.of(p));
+                when(profileRepository.save(any(Profile.class))).thenAnswer(inv -> inv.getArgument(0));
+
+                List<String> input = List.of("Programación", "Programación", "Software");
+                Profile saved = profileService.addAreas(11L, input);
+
+                assertThat(saved.getAreas()).containsExactlyInAnyOrder("Programación", "Software");
+        }
+}
+


### PR DESCRIPTION
## Summary
- Guarantee distinct timestamps for saved notifications to preserve retrieval order
- Run application tests under the `test` profile to load in-memory database configuration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fcf01521c8320988569802f3c8ee5